### PR TITLE
Format fasta

### DIFF
--- a/include/bio/detail/charconv.hpp
+++ b/include/bio/detail/charconv.hpp
@@ -19,6 +19,8 @@
 #include <ranges>
 #include <string_view>
 
+#include <seqan3/utility/concept/exposition_only/core_language.hpp>
+
 #include <bio/platform.hpp>
 
 namespace bio::detail
@@ -55,6 +57,43 @@ std::to_chars_result to_chars(char * first, char * last, auto in)
         return {.ptr = first + count, .ec{}};
     }
 }
+
+/*!\brief Turn a string into a number.
+ * \param[in] input The input string.
+ * \param[out] number The variable holding the result.
+ * \throws std::runtime_error If there was an error during conversion.
+ * \details
+ *
+ * Relies on std::from_chars to efficiently convert but accepts std::string_view and throws on error so
+ * there is no return value that needs to be checked.
+ */
+void string_to_number(std::string_view const input, seqan3::arithmetic auto & number)
+{
+    std::from_chars_result res = std::from_chars(input.data(), input.data() + input.size(), number);
+    if (res.ec != std::errc{} || res.ptr != input.data() + input.size())
+        throw std::runtime_error{std::string{"Could not convert \""} + std::string{input} + "\" into a number."};
+}
+
+/*!\brief Convert something to a string.
+ * \details
+ *
+ * ### Attention
+ *
+ * This function is not efficient. Do not use it in performance-critical code.
+ */
+std::string to_string(auto && in)
+{
+    using in_t = std::remove_cvref_t<decltype(in)>;
+    if constexpr (seqan3::arithmetic<in_t>)
+        return std::to_string(in);
+    else if constexpr (std::same_as<in_t, std::string>)
+        return in;
+    else if constexpr (std::constructible_from<std::string, in_t>)
+        return std::string{in};
+    else
+        static_assert(std::constructible_from<std::string, in_t>, "Type cannot be converted to string");
+}
+
 //!\}
 
 } // namespace bio::detail

--- a/include/bio/detail/range.hpp
+++ b/include/bio/detail/range.hpp
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2020-2021, deCODE Genetics
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides various range utilities.
+ * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
+ */
+
+#pragma once
+
+#include <seqan3/alphabet/concept.hpp>
+#include <seqan3/utility/concept/container.hpp>
+
+#include <bio/platform.hpp>
+
+namespace bio::detail
+{
+
+/*!\addtogroup bio
+ * \{
+ */
+
+/*!\brief Copy elements from the first range into the second range.
+ * \param[in] in The range to copy from.
+ * \param[out] out The range to copy to.
+ * \details
+ *
+ * By default, this function behaves like std::ranges::copy with a std::back_insert_iterator. It assumes that
+ * the target range is empty (and clears it if possible).
+ *
+ * If the input range is sized and the target range offers a `.resize()` member, this function uses
+ * resize and assignment instead of back-insertion.
+ */
+void sized_range_copy(std::ranges::input_range auto &&                                                   in,
+                      seqan3::back_insertable_with<std::ranges::range_reference_t<decltype(in)>> auto && out)
+{
+    using in_t  = decltype(in);
+    using out_t = decltype(out);
+
+    if constexpr (std::ranges::sized_range<in_t> && requires(out_t out) { out.resize(0); })
+    {
+        out.resize(std::ranges::size(in));
+        std::ranges::copy(in, std::ranges::begin(out));
+    }
+    else
+    {
+        if constexpr (requires(out_t out) { out.clear(); })
+            out.clear();
+        std::ranges::copy(in, std::back_inserter(out));
+    }
+}
+
+//!\brief Like bio::detail::sized_range_copy except that if input and output are both std::string_view, it assigns.
+void string_copy(std::string_view const in, auto & out)
+{
+    if constexpr (std::same_as<decltype(out), std::string_view &>)
+        out = in;
+    else
+        sized_range_copy(in, out);
+}
+
+//!\brief A seqan3::alphabet that is **not** a character or number (any std::integral).
+template <typename t>
+concept deliberate_alphabet = seqan3::alphabet<t> && !std::integral<std::remove_cvref_t<t>>;
+
+//!\brief A range whose value type is `char`.
+template <typename t>
+concept char_range = std::ranges::range<t> && std::same_as<char, std::remove_cvref_t<std::ranges::range_value_t<t>>>;
+
+//!\brief A range whose value type is an integral type other than `char`.
+template <typename t>
+concept int_range = std::ranges::range<t> && std::integral<std::remove_cvref_t<std::ranges::range_value_t<t>>> &&
+  !std::same_as<char, std::remove_cvref_t<std::ranges::range_value_t<t>>>;
+
+//!\brief A type that is not std::span<std::byte const>.
+template <typename t>
+concept not_a_byte_span = !std::same_as<t, std::span<std::byte const>>;
+
+//!\}
+
+} // namespace bio::detail

--- a/include/bio/format/all.hpp
+++ b/include/bio/format/all.hpp
@@ -1,0 +1,21 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2020-2021, deCODE Genetics
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/b.i.o./blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Meta-include that includes all formats.
+ * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
+ */
+
+#pragma once
+
+// TODO
+
+/*!\defgroup format Format
+ * \ingroup bio
+ * \brief File format implementations. Note that most users should read/write formats through readers/writers instead.
+ */

--- a/include/bio/format/fasta.hpp
+++ b/include/bio/format/fasta.hpp
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2020-2021, deCODE Genetics
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * brief Provides the seqan3::format_fasta.
+ * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <bio/platform.hpp>
+
+namespace bio
+{
+
+/*!\brief       The FastA format.
+ * \ingroup     format
+ *
+ * \details
+ *
+ * This is the FastA format tag. If you want to read FastA files, use bio::seq_io::reader, and if you want
+ * to write FastA files, use bio::seq_io::writer.
+ *
+ * ### Introduction
+ *
+ * FastA is the de-facto-standard for sequence storage in bionformatics. See the
+ * [article on wikipedia](https://en.wikipedia.org/wiki/FASTA_format) for a an in-depth description of the format.
+ *
+ * ### Fields
+ *
+ * The FastA format provides the fields bio::field::seq and bio::field::id. Both fields are required when writing.
+ *
+ * ### Implementation notes
+ *
+ * When reading the ID-line, the identifier (either `;` or `>`) is stripped.
+ *
+ * This implementation supports the following less known and optional features of the format:
+ *
+ *   * ID lines beginning with `;` instead of `>`.
+ *   * Line breaks and other whitespace characters in any part of the sequence.
+ *   * Character counts within the sequence (they are simply ignored/stripped).
+ *
+ * The following optional features are currently **not supported:**
+ *
+ *   * Multiple comment lines (starting with either `;` or `>`); only one ID line before the sequence line is accepted.
+ *
+ */
+struct fasta
+{
+    //!\brief The valid file extensions for this format; note that you can modify this value.
+    static inline std::vector<std::string> file_extensions{
+      {"fasta"},
+      {"fa"},
+      {"fna"},
+      {"ffn"},
+      {"faa"},
+      {"frn"},
+      {"fas"},
+    };
+};
+
+} // namespace bio

--- a/include/bio/format/fasta_input_handler.hpp
+++ b/include/bio/format/fasta_input_handler.hpp
@@ -1,0 +1,227 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2020-2021, deCODE Genetics
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides the bio::format_input_handler implementation for bio::fasta.
+ * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <iostream>
+#include <ranges>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <seqan3/core/range/type_traits.hpp>
+
+#include <seqan3/alphabet/views/to_char.hpp>
+#include <seqan3/core/debug_stream/detail/to_string.hpp>
+#include <seqan3/utility/char_operations/predicate.hpp>
+
+#include <bio/detail/range.hpp>
+#include <bio/format/fasta.hpp>
+#include <bio/format/format_input_handler.hpp>
+#include <bio/plain_io/reader.hpp>
+
+namespace bio
+{
+
+/*!\brief Format input handler for the FASTA format (bio::fasta).
+ * \ingroup format
+ * \details
+ *
+ * ### Attention
+ *
+ * Most users should not perform I/O through input/output handlers but should instead use the respective
+ * readers/writers. See the overview (TODO link) for more information.
+ *
+ * ### Options
+ *
+ * The following options are considered if the respective member variable is availabele in the object passed to
+ * the constructor:
+ *
+ * | Member        | Type    | Default | Description                                      |
+ * |---------------|---------|---------|--------------------------------------------------|
+ * |`truncate_ids` |`bool`   | `false` | Whether to truncate IDs on the first whitespace  |
+ *
+ * ### Performance
+ *
+ * Since FASTA records can be exceptionally large, FASTA input always involves an additional buffering step.
+ * Even when performing raw or lowlevel I/O (returning std::string_view or std::span<std::byte const>), all data
+ * is typically copied once from the input stream buffer. This also means, that raw I/O does not preserve formatting
+ * (e.g. linebreaks) as-is.
+ *
+ * If sequence and/or ID are requested as std::string, the record's element is swapped with the internal buffer to
+ * prevent a second copy, but if output is requested as e.g. std::vector<seqan3::dna4>, a second copy needs to happen.
+ * Requesting views never implies a second copy.
+ */
+template <>
+class format_input_handler<fasta> : public format_input_handler_base<format_input_handler<fasta>>
+{
+private:
+    /*!\name CRTP related entities
+     * \{
+     */
+    //!\brief The type of the CRTP base class.
+    using base_t = format_input_handler_base<format_input_handler<fasta>>;
+    using base_t::parse_field;
+    using base_t::parse_field_aux;
+    using base_t::stream;
+
+    //!\brief Befriend the base class to enable CRTP.
+    friend base_t;
+    //!\}
+
+    //!\brief Print an error message with current line number in diagnostic.
+    [[noreturn]] void error(auto const &... messages) const
+    {
+        std::string message = "[B.I.O. FASTA format error in line " + detail::to_string(line) + "] ";
+        ((message += detail::to_string(messages)), ...);
+
+        throw parse_error{message};
+    }
+
+    /*!\name Options
+     * \{
+     */
+    //!\brief Whether to truncate IDs on first whitespace.
+    bool truncate_ids = false;
+    //!\}
+
+    /*!\name Raw record handling
+     * \{
+     */
+    //!\brief The fields that this format supports [the base class accesses this type].
+    using format_fields     = seqan3::vtag_t<field::id, field::seq>;
+    //!\brief Type of the raw record.
+    using raw_record_type   = record<format_fields, std::string_view, std::string_view>;
+    //!\brief Type of the low-level iterator.
+    using lowlevel_iterator = detail::plaintext_input_iterator<plain_io::record_kind::line>;
+
+    //!\brief The raw record.
+    raw_record_type raw_record;
+    //!\brief Buffer for the ID.
+    std::string     id_buffer;
+    //!\brief Buffer for the sequence.
+    std::string     seq_buffer;
+
+    //!\brief The low-level iterator.
+    lowlevel_iterator it;
+    //!\brief A line counter.
+    size_t            line = -1;
+
+    //!\brief Read the raw record [the base class invokes this function].
+    void read_raw_record()
+    {
+        constexpr auto not_id = !(seqan3::is_char<'>'> || seqan3::is_char<';'>);
+
+        id_buffer.clear();
+        seq_buffer.clear();
+        raw_record.clear();
+
+        /* READ ID */
+        ++it;
+        ++line;
+
+        if (it == std::default_sentinel)
+            error("Reached end of file while trying to read ID.");
+
+        std::string_view current_line = *it;
+
+        if (current_line.empty())
+            error("Expected to be on begin of record but is on empty line.");
+
+        if (not_id(current_line[0]))
+            error("Record does not begin with '>' or ';'.");
+
+        if (truncate_ids)
+        {
+            size_t e = 1;
+            for (; e < current_line.size() && (!seqan3::is_space)(current_line[e]); ++e)
+            {}
+            detail::string_copy(current_line.substr(1, e - 1), id_buffer);
+        }
+        else
+        {
+            detail::string_copy(current_line.substr(1), id_buffer);
+        }
+        get<field::id>(raw_record) = id_buffer;
+
+        /* READ SEQ */
+        /* Implementation NOTE: we create and compare a streambuf iterator here and do not check the line-iterator
+         * (it != std::default_sentinel) && ...
+         * because the line-iterator is "at end" one iteration later than the stream itself [it holds the line just
+         * before the current stream-buffer pointer]. If we don't do this, the peak() might fail.
+         */
+        while ((std::istreambuf_iterator<char>{*stream} != std::istreambuf_iterator<char>{}) && not_id(it.peak()))
+        {
+            ++it;
+            ++line;
+            std::ranges::copy(*it | std::views::filter(!(seqan3::is_space || seqan3::is_digit)),
+                              std::back_insert_iterator{seq_buffer});
+        }
+
+        if (seq_buffer.empty())
+            error("No sequence or no valid sequence characters.");
+        get<field::seq>(raw_record) = seq_buffer;
+    }
+    //!\}
+
+    /*!\name Parsed record handling
+     * \brief This is mostly done via the defaults in the base class.
+     * \{
+     */
+    //!\brief We can prevent another copy if the user wants a string.
+    void parse_field(seqan3::vtag_t<field::id> const & /**/, std::string & parsed_field)
+    {
+        std::swap(id_buffer, parsed_field);
+    }
+
+    //!\brief We can prevent another copy if the user wants a string.
+    void parse_field(seqan3::vtag_t<field::seq> const & /**/, std::string & parsed_field)
+    {
+        std::swap(seq_buffer, parsed_field);
+    }
+    //!\}
+
+public:
+    /*!\name Constructors, destructor and assignment.
+     * \{
+     */
+    format_input_handler()                             = default;            //!< Defaulted.
+    format_input_handler(format_input_handler const &) = delete;             //!< Deleted.
+    format_input_handler(format_input_handler &&)      = default;            //!< Defaulted.
+    ~format_input_handler()                            = default;            //!< Defaulted.
+    format_input_handler & operator=(format_input_handler const &) = delete; //!< Deleted.
+    format_input_handler & operator=(format_input_handler &&) = default;     //!< Defaulted.
+
+    /*!\brief Construct with an options object.
+     * \param[in,out] str The input stream.
+     * \param[in] options An object with options for the format.
+     * \details
+     *
+     * The options argument is typically bio::seq_io::reader_options, but any object with a subset of similarly named
+     * members is also accepted. See bio::format_input_handler<bio::fasta> for the supported options and defaults.
+     */
+    format_input_handler(std::istream & str, auto const & options) : base_t{str}, it{str, false}
+    {
+        if constexpr (requires { (bool)options.truncate_ids; })
+        {
+            truncate_ids = options.truncate_ids;
+        }
+    }
+
+    //!\brief Construct with only an input stream.
+    format_input_handler(std::istream & str) : format_input_handler{str, int{}} {}
+    //!\}
+};
+
+} // namespace bio

--- a/include/bio/format/format_input_handler.hpp
+++ b/include/bio/format/format_input_handler.hpp
@@ -1,0 +1,221 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2020-2021, deCODE Genetics
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides bio::format_input_handler and bio::format_input_handler_base.
+ * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
+ */
+
+#pragma once
+
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include <seqan3/alphabet/views/char_to.hpp> // TODO replace with char_strictly_to
+#include <seqan3/utility/concept/container.hpp>
+
+#include <bio/detail/charconv.hpp>
+#include <bio/detail/range.hpp>
+#include <bio/exception.hpp>
+#include <bio/record.hpp>
+
+namespace bio
+{
+
+/*!\brief A template that provides the reading and parsing functionality of the specified format.
+ * \ingroup format
+ * \details
+ *
+ * Formats need to specialise this template and provide a constructor that accepts an std::istream as well as a
+ * public member function with the following signature:
+ * ```cpp
+ * void parse_next_record_into(auto & parsed_record);
+ * ```
+ * It must accept any bio::record and "fill" that record with the content found in that file.
+ *
+ * This template may be specialised with a user-provided type, however the process is non-trivial. Documentation
+ * can be found here (TODO).
+ */
+template <typename format_t>
+class format_input_handler;
+
+/*!\brief A CRTP base class that helps implement bio::format_input_handler.
+ * \ingroup format
+ * \details
+ *
+ * The details of this base class are currently not exposed and shall thus not be relied upon by user code.
+ */
+template <typename derived_t>
+class format_input_handler_base
+{
+private:
+    /*!\name CRTP related entities
+     * \{
+     */
+    //!\brief Befriend the derived type so it can instantiate.
+    friend derived_t;
+
+    //!\brief Downcast self to derived type.
+    derived_t * to_derived() { return static_cast<derived_t *>(this); }
+
+    //!\brief Downcast self to derived type. [const-qualified version]
+    derived_t const * to_derived() const { return static_cast<derived_t const *>(this); }
+    //!\}
+
+    /* members */
+    //!\brief A pointer to the input stream.
+    std::istream * stream = nullptr;
+
+    /* stuff for turning raw record into parsed record */
+
+    /*!\name Parsing individual fields - defaults (step 3)
+     * \brief These are sane defaults for text based formats (not taken for binary formats).
+     * \{
+     */
+    //!\brief Not parsing at all / *raw IO*; binary formats' raw record is bytes already.
+    static inline void parse_field_aux(std::span<std::byte const> const in, std::span<std::byte const> & parsed_field)
+    {
+        parsed_field = in;
+    }
+
+    //!\brief Not parsing at all / *raw IO*.
+    static inline void parse_field_aux(std::string_view const in, std::span<std::byte const> & parsed_field)
+    {
+        parsed_field = std::span<std::byte const>{reinterpret_cast<std::byte const *>(in.data()), in.size()};
+    }
+
+    //!\brief Parsing into string views. override this.
+    static inline void parse_field_aux(std::string_view const in, std::string_view & parsed_field)
+    {
+        parsed_field = in;
+    }
+
+    //!\brief Parsing into transformed string views.
+    template <typename fun_t>
+    static void parse_field_aux(std::string_view const                                 in,
+                                std::ranges::transform_view<std::string_view, fun_t> & parsed_field)
+    {
+        parsed_field = std::ranges::transform_view<std::string_view, fun_t>{in, fun_t{}};
+    }
+
+    //!\brief Parse into string-like types.
+    template <seqan3::back_insertable parsed_field_t>
+        requires detail::char_range<parsed_field_t>
+    static void parse_field_aux(std::string_view const in, parsed_field_t & parsed_field)
+    {
+        detail::sized_range_copy(in, parsed_field);
+    }
+
+    //!\brief Parse into containers of alphabets.
+    template <seqan3::back_insertable parsed_field_t>
+        requires detail::deliberate_alphabet<std::ranges::range_reference_t<parsed_field_t>>
+    static void parse_field_aux(std::string_view const in, parsed_field_t & parsed_field)
+    {
+        using target_alph_type = std::ranges::range_value_t<parsed_field_t>;
+        //         detail::sized_range_copy(in | seqan3::views::char_strictly_to<target_alph_type>,
+        detail::sized_range_copy(in | seqan3::views::char_to<target_alph_type>, parsed_field);
+    }
+
+    //!\brief Parse into a numerical type.
+    template <seqan3::arithmetic parsed_field_t>
+    static void parse_field_aux(std::string_view const in, parsed_field_t & parsed_field)
+    {
+        detail::string_to_number(in, parsed_field);
+    }
+    //!\}
+
+    /*!\name Parsing individual fields (step 2)
+     * \brief The second step in parsing consists of field-specific parsing. This is typically provided by derived_t.
+     * \{
+     */
+    //!\brief Default is no handler.
+    template <typename tag_type, typename parsed_field_t>
+    void parse_field(tag_type const & /**/, parsed_field_t &)
+    {
+        // TODO replace X Y and Z with actual strings generated from types.
+        static_assert(seqan3::arithmetic<parsed_field_t> /*always false*/,
+                      "Format X does not know how to parse field Y into type Z. Provide different traits or a "
+                      "custom format handler.");
+    }
+
+    //!\brief Various target types have sane default implementations.
+    template <field field_id, typename parsed_field_t>
+    void parse_field(seqan3::vtag_t<field_id> const & /**/, parsed_field_t & parsed_field) requires(requires {
+        derived_t::parse_field_aux(get<field_id>(to_derived()->raw_record), parsed_field);
+    })
+    {
+        to_derived()->parse_field_aux(get<field_id>(to_derived()->raw_record), parsed_field);
+    }
+    //!\}
+
+    /*!\name Parsing record (step 1)
+     * \brief The first step in parsing decomposes the record.
+     * \{
+     */
+    //!\brief Only act on those fields that are present in the record and also provided by the format.
+    template <field field_id, typename parsed_record_t>
+    void parse_record_impl(seqan3::vtag_t<field_id> const & /**/, parsed_record_t & parsed_record)
+    {
+        if constexpr (parsed_record_t::field_ids::contains(field_id))
+        {
+            auto & parsed_field = get<field_id>(parsed_record);
+            to_derived()->parse_field(seqan3::vtag<field_id>, parsed_field);
+        }
+        // fields that are not in format or not in target record are simply ignored
+    }
+
+    //!\brief Splits the record into individual fields.
+    template <field... field_ids, typename parsed_record_t>
+    void parse_record(seqan3::vtag_t<field_ids...> const & /**/, parsed_record_t & parsed_record)
+    {
+        (to_derived()->parse_record_impl(seqan3::vtag<field_ids>, parsed_record), ...);
+    }
+    //!\}
+
+    /*!\name Constructors, destructor and assignment.
+     * \brief These are all private to prevent wrong instantiation.
+     * \{
+     */
+    format_input_handler_base()                                  = default;            //!< Defaulted.
+    format_input_handler_base(format_input_handler_base const &) = delete;             //!< Deleted.
+    format_input_handler_base(format_input_handler_base &&)      = default;            //!< Defaulted.
+    ~format_input_handler_base()                                 = default;            //!< Defaulted.
+    format_input_handler_base & operator=(format_input_handler_base const &) = delete; //!< Deleted.
+    format_input_handler_base & operator=(format_input_handler_base &&) = default;     //!< Defaulted.
+
+    //!\brief Construct from a std::istream.
+    format_input_handler_base(std::istream & str) : stream{&str}
+    {
+        if (std::istreambuf_iterator<char>{*stream} == std::istreambuf_iterator<char>{})
+            throw bio::file_open_error{"The file was empty."};
+    }
+    //!\}
+
+public:
+    /*!\brief Parse input into the record argument.
+     * \param[out] parsed_record The out-parameter.
+     * \details
+     *
+     * ### Attention
+     *
+     * Most users should not use this interface and should instead use formatted readers, e.g.
+     * bio::map_io::reader, bio::seq_io::reader or bio::var_io::reader.
+     */
+    void parse_next_record_into(auto & parsed_record)
+    {
+        // create new raw record
+        to_derived()->read_raw_record();
+
+        // create new parsed record
+        parsed_record.clear();
+        to_derived()->parse_record(typename derived_t::format_fields{}, parsed_record);
+    }
+};
+
+} // namespace bio

--- a/include/bio/plain_io/reader.hpp
+++ b/include/bio/plain_io/reader.hpp
@@ -252,7 +252,13 @@ public:
             return record_.line;
     }
     //!\brief Arrow operator.
-    pointer operator->() const { return &**this; }
+    pointer operator->() const
+    {
+        if constexpr (record_kind_ == plain_io::record_kind::line_and_fields)
+            return &record_;
+        else
+            return &record_.line;
+    }
 
     /*!\brief Show the character behind the current record.
      * \details

--- a/include/bio/plain_io/reader.hpp
+++ b/include/bio/plain_io/reader.hpp
@@ -261,18 +261,21 @@ public:
     }
 
     /*!\brief Show the character behind the current record.
+     * \throws io_error If the stream is at end.
      * \details
+     *
      * ### ATTENTION
      * Calling this function may invalidate the current record!
-     *
-     * Undefined behaviour if the stream is at end!
      */
     char peak()
     {
         assert(stream_buf != nullptr);
+
         if (stream_buf->gptr() == stream_buf->egptr())
             stream_buf->underflow();
-        assert(stream_buf->gptr() != stream_buf->egptr());
+        if (stream_buf->gptr() == stream_buf->egptr())
+            throw io_error{"Cannot peak() into stream if the stream is EOF."};
+
         return *stream_buf->gptr();
     }
     //!\}

--- a/include/bio/record.hpp
+++ b/include/bio/record.hpp
@@ -200,11 +200,13 @@ public:
 
 //!\brief A macro that defines all getter functions for fields contained in bio::record.
 #define BIO_RECORD_MEMBER(F)                                                                                           \
+    /*!\brief Return the bio::field F if available.*/                                                                  \
     decltype(auto) F() noexcept(noexcept(get<field::F>())) { return get<field::F>(); }                                 \
-                                                                                                                       \
+    /*!\brief Return the bio::field F if available. [const-qualified version] */                                       \
     decltype(auto) F() const noexcept(noexcept(get<field::F>())) { return get<field::F>(); }
 
-    /*\name Member accessors
+    /*!\name Member accessors
+     * \brief This is the same as calling #get<field::X>(); functions are only defined if record has that element.
      * \{
      */
     BIO_RECORD_MEMBER(seq)
@@ -229,7 +231,7 @@ public:
     BIO_RECORD_MEMBER(filter)
     BIO_RECORD_MEMBER(info)
     BIO_RECORD_MEMBER(genotypes)
-    //\}
+    //!\}
 #undef BIO_RECORD_MEMBER
 };
 

--- a/test/documentation/bio_doxygen_cfg.in
+++ b/test/documentation/bio_doxygen_cfg.in
@@ -56,7 +56,7 @@ PREDEFINED             = "CEREAL_SERIALIZE_FUNCTION_NAME=serialize" \
                          "BIO_DOXYGEN_ONLY(x)= x" \
                          "${BIO_DOXYGEN_PREDEFINED_NDEBUG}"
 
-##EXPAND_AS_DEFINED      = BIO_RECORD_MEMBER
+EXPAND_AS_DEFINED      = BIO_RECORD_MEMBER
 
 TAGFILES               += "${BIO_DOXYGEN_STD_TAGFILE}=https://en.cppreference.com/w/"
 

--- a/test/unit/format/CMakeLists.txt
+++ b/test/unit/format/CMakeLists.txt
@@ -1,0 +1,1 @@
+bio_test(fasta_input_test.cpp)

--- a/test/unit/format/fasta_input_test.cpp
+++ b/test/unit/format/fasta_input_test.cpp
@@ -1,0 +1,301 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <algorithm>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include <seqan3/alphabet/nucleotide/dna4.hpp>
+#include <seqan3/alphabet/nucleotide/dna5.hpp>
+#include <seqan3/alphabet/quality/phred42.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/test/expect_range_eq.hpp>
+#include <seqan3/test/expect_same_type.hpp>
+
+#include <bio/format/fasta_input_handler.hpp>
+
+using seqan3::                             operator""_dna5;
+using seqan3::                             operator""_phred42;
+using std::literals::string_view_literals::operator""sv;
+
+// ----------------------------------------------------------------------------
+// fixture
+// ----------------------------------------------------------------------------
+
+struct read : public ::testing::Test
+{
+    using default_rec_t = bio::record<seqan3::vtag_t<bio::field::id, bio::field::seq>,
+                                      std::string_view,
+                                      decltype(std::string_view{} | seqan3::views::char_to<seqan3::dna5>)>;
+
+    std::vector<std::string> ids{
+      {"ID1"},
+      {"ID2"},
+      {"ID3 lala"},
+    };
+
+    std::vector<std::vector<seqan3::dna5>> seqs{
+      {"ACGTTTTTTTTTTTTTTT"_dna5},
+      {"ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT"_dna5},
+      {"ACGTTTA"_dna5},
+    };
+
+    std::vector<std::vector<seqan3::phred42>> quals{
+      {"!##$%&'()*+,-./++-"_phred42},
+      {"!##$&'()*+,-./+)*+,-)*+,-)*+,-)*+,BDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDEBDE"_phred42},
+      {"!!!!!!!"_phred42},
+    };
+
+    template <typename id_t, typename seq_t>
+    void do_read_test_impl(std::string const & input)
+    {
+        std::istringstream istream{input};
+
+        bio::format_input_handler<bio::fasta> input_handler{istream};
+
+        bio::record<seqan3::vtag_t<bio::field::id, bio::field::seq>, id_t, seq_t> rec;
+
+        for (unsigned i = 0; i < 3; ++i)
+        {
+            input_handler.parse_next_record_into(rec);
+            if constexpr (std::same_as<std::ranges::range_value_t<seq_t>, char>)
+            {
+                EXPECT_RANGE_EQ(rec.seq() | seqan3::views::char_to<seqan3::dna5>, seqs[i]);
+            }
+            else
+            {
+                EXPECT_RANGE_EQ(rec.seq(), seqs[i]);
+            }
+            EXPECT_RANGE_EQ(rec.id(), ids[i]);
+        }
+    }
+
+    void do_read_test(std::string const & input)
+    {
+        /* containers */
+        do_read_test_impl<std::string, std::string>(input);
+        do_read_test_impl<std::string, std::vector<seqan3::dna5>>(input);
+
+        /* views */
+        do_read_test_impl<std::string_view, std::string_view>(input);
+        do_read_test_impl<std::string_view, decltype(std::string_view{} | seqan3::views::char_to<seqan3::dna5>)>(input);
+    }
+};
+
+// ----------------------------------------------------------------------------
+// simple tests
+// ----------------------------------------------------------------------------
+
+TEST_F(read, simple)
+{
+    std::string input =
+      R"raw(>ID1
+ACGTTTTTTTTTTTTTTT
+>ID2
+ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+>ID3 lala
+ACGTTTA
+)raw";
+
+    do_read_test(input);
+}
+
+TEST_F(read, no_trailing_newline)
+{
+    std::string input =
+      R"raw(>ID1
+ACGTTTTTTTTTTTTTTT
+>ID2
+ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+>ID3 lala
+ACGTTTA)raw";
+
+    do_read_test(input);
+}
+
+TEST_F(read, empty_lines)
+{
+    std::string input =
+      R"raw(>ID1
+ACGTTTTTTTTTTTTTTT
+
+>ID2
+ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+
+>ID3 lala
+ACGTTTA
+)raw";
+
+    do_read_test(input);
+}
+
+TEST_F(read, whitespace_in_seq)
+{
+    std::string input =
+      R"raw(>ID1
+ACGTTTT
+TTTTTTTT
+TTT
+>ID2
+ACGTTTTTT TTTTTTTTT TTTTTTTT TTTTTTTTTT
+TTTTTTTTT TTTTTTTTT TTTTTTTT TTTTTTTTTT
+TTTTTTTTT T
+>ID3 lala
+ACGT	TTA
+)raw";
+
+    do_read_test(input);
+}
+
+TEST_F(read, digits_in_seq)
+{
+    std::string input =
+      R"raw(>ID1
+10  ACGTTTTTTTTTTTTTTT
+>ID2
+  80 ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT  900
+1000 TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+>ID3 lala
+ACGT9T5T2A
+)raw";
+
+    do_read_test(input);
+}
+
+TEST_F(read, old_id_style)
+{
+    std::string input =
+      R"raw(;ID1
+ACGTTTTTTTTTTTTTTT
+;ID2
+ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+;ID3 lala
+ACGTTTA
+)raw";
+
+    do_read_test(input);
+}
+
+// ----------------------------------------------------------------------------
+// custom tests
+// ----------------------------------------------------------------------------
+
+struct options_t
+{
+    bool truncate_ids = false;
+};
+
+TEST_F(read, truncate_ids_off)
+{
+    std::string input =
+      R"raw(>ID1 foo
+ACGTTTTTTTTTTTTTTT
+>ID2
+ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+>ID3 lala
+ACGTTTA
+)raw";
+
+    std::istringstream                    istream{input};
+    bio::format_input_handler<bio::fasta> input_handler{istream, options_t{}};
+    default_rec_t                         rec;
+
+    input_handler.parse_next_record_into(rec);
+    EXPECT_RANGE_EQ(rec.id(), "ID1 foo"sv);
+    EXPECT_RANGE_EQ(rec.seq(), seqs[0]);
+    input_handler.parse_next_record_into(rec);
+    EXPECT_RANGE_EQ(rec.id(), "ID2"sv);
+    EXPECT_RANGE_EQ(rec.seq(), seqs[1]);
+    input_handler.parse_next_record_into(rec);
+    EXPECT_RANGE_EQ(rec.id(), "ID3 lala"sv);
+    EXPECT_RANGE_EQ(rec.seq(), seqs[2]);
+}
+
+TEST_F(read, truncate_ids_on)
+{
+    std::string input =
+      R"raw(>ID1 foo
+ACGTTTTTTTTTTTTTTT
+>ID2
+ACGTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+>ID3 lala
+ACGTTTA
+)raw";
+
+    std::istringstream                    istream{input};
+    bio::format_input_handler<bio::fasta> input_handler{istream, options_t{.truncate_ids = true}};
+    default_rec_t                         rec;
+
+    input_handler.parse_next_record_into(rec);
+    EXPECT_RANGE_EQ(rec.id(), "ID1"sv);
+    EXPECT_RANGE_EQ(rec.seq(), seqs[0]);
+    input_handler.parse_next_record_into(rec);
+    EXPECT_RANGE_EQ(rec.id(), "ID2"sv);
+    EXPECT_RANGE_EQ(rec.seq(), seqs[1]);
+    input_handler.parse_next_record_into(rec);
+    EXPECT_RANGE_EQ(rec.id(), "ID3"sv);
+    EXPECT_RANGE_EQ(rec.seq(), seqs[2]);
+}
+
+// ----------------------------------------------------------------------------
+// failure
+// ----------------------------------------------------------------------------
+
+TEST_F(read, fail_no_input)
+{
+    std::string input{};
+
+    std::istringstream istream{input};
+    EXPECT_THROW(bio::format_input_handler<bio::fasta>{istream}, bio::file_open_error);
+}
+
+TEST_F(read, fail_no_id)
+{
+    std::string input{"foo\nACGT"};
+
+    std::istringstream                    istream{input};
+    bio::format_input_handler<bio::fasta> input_handler{istream};
+    default_rec_t                         rec;
+
+    EXPECT_THROW(input_handler.parse_next_record_into(rec), bio::parse_error);
+}
+
+TEST_F(read, fail_only_id)
+{
+    std::string input{">foo"};
+
+    std::istringstream                    istream{input};
+    bio::format_input_handler<bio::fasta> input_handler{istream};
+    default_rec_t                         rec;
+
+    EXPECT_THROW(input_handler.parse_next_record_into(rec), bio::parse_error);
+}
+
+TEST_F(read, fail_no_seq)
+{
+    std::string input{">foo\n>bar"};
+
+    std::istringstream                    istream{input};
+    bio::format_input_handler<bio::fasta> input_handler{istream};
+    default_rec_t                         rec;
+
+    EXPECT_THROW(input_handler.parse_next_record_into(rec), bio::parse_error);
+}
+
+// TODO activate after switch to seqan3::views::char_strictly_to
+// TEST_F(read, fail_illegal_alphabet)
+// {
+//     std::string input{">foo\nFOOBAR\n"};
+//
+//     std::istringstream istream{input};
+//     bio::format_input_handler<bio::fasta> input_handler{istream};
+//     using rec_t = bio::record<seqan3::vtag_t<bio::field::id, bio::field::seq>, std::string_view,
+//     std::vector<seqan3::dna5>>; rec_t rec;
+//
+//     EXPECT_THROW(input_handler.parse_next_record_into(rec), seqan3::invalid_char_assignment);
+// }


### PR DESCRIPTION
This adds the FASTA format as a first step for seq_io. 

Since everything is modular now, the format can be tested without the file/reader.

P.S.: I managed to fix the documentation of the record.