### PR TITLE
[infra] Ignore unused-variable warning in snippets.

### DIFF
--- a/test/snippet/CMakeLists.txt
+++ b/test/snippet/CMakeLists.txt
@@ -24,6 +24,7 @@ macro (bio_snippet test_name_prefix snippet snippet_base_path)
 
     add_executable (${target} "${snippet_base_path}/${snippet}")
     target_link_libraries (${target} PUBLIC snippet_main bio::bio)
+    target_compile_options (${target} PUBLIC "-Wno-unused")
     set_target_properties(${target}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${snippet_target_path}"


### PR DESCRIPTION
So in this PR https://github.com/seqan/seqan3/pull/2806 the unsued warning was introduced again. I'll ask why. But in the meantime you can use this if you want. Maybe cherry pick this and check before you merge.