### PR TITLE
field_types check

### DIFF
--- a/include/bio/detail/magic_get.hpp
+++ b/include/bio/detail/magic_get.hpp
@@ -34,7 +34,7 @@ concept tuple_of_two = requires
     std::tuple_size<t>::value;
 }
 &&std::tuple_size<t>::value == 2;
-;
+
 //!\endcond
 
 /*!\brief A type that can be converted to any reference type.

--- a/include/bio/detail/misc.hpp
+++ b/include/bio/detail/misc.hpp
@@ -71,6 +71,29 @@ void set_format(auto & format, std::filesystem::path const & file_name)
         throw unhandled_extension_error("No valid format found for this extension.");
 }
 
+//!\brief Wrapper to create an overload set of multiple functors.
+template <typename... functors>
+struct overloaded : functors...
+{
+    using functors::operator()...;
+};
+
+//!\brief Deduction guide for bio::detail::overloaded.
+template <typename... functors>
+overloaded(functors...) -> overloaded<functors...>;
+
+/*!\brief Pass this function a constrained functor that accepts one argument and returns std::true_type.
+ * \details
+ *
+ * See e.g. bio::seq_io::reader_options to see how this is used.
+ */
+constexpr bool lazy_concept_checker(auto fun)
+{
+    auto fallback = []<typename T = int>(auto) { return std::false_type{}; };
+    using ret_t   = decltype(detail::overloaded{fallback, fun}(1));
+    return ret_t::value;
+}
+
 //!\}
 
 } // namespace bio::detail

--- a/include/bio/detail/range.hpp
+++ b/include/bio/detail/range.hpp
@@ -72,6 +72,23 @@ concept vector_like = std::ranges::random_access_range<rng_t> && std::ranges::si
     v.clear();
 };
 
+//!\brief Helper for bio::detail::transform_view_on_string_view.
+template <typename fun_t>
+void transform_view_on_string_view_impl(std::ranges::transform_view<std::string_view, fun_t> &)
+{}
+
+/*!\interface   bio::detail::transform_view_on_string_view <>
+ * \tparam t    The query type to check.
+ * \brief       std::ranges::transform_view<std::string_view, fun_t> where fun_t is any valid functor type.
+ */
+//!\cond
+template <typename t>
+concept transform_view_on_string_view = requires
+{
+    transform_view_on_string_view_impl(std::declval<t &>());
+};
+//!\endcond
+
 // ----------------------------------------------------------------------------
 // copy functions
 // ----------------------------------------------------------------------------

--- a/include/bio/misc.hpp
+++ b/include/bio/misc.hpp
@@ -141,3 +141,16 @@ template <typename type, typename... more_types>
 inline constexpr seqan3::type_list<type, more_types...> ttag{};
 
 } // namespace bio
+
+namespace bio::detail
+{
+
+//!\brief Check whether a type is a specialisation of seqan3::type_list.
+template <typename t>
+inline constexpr bool is_type_list = false;
+
+//!\brief Check whether a type is a specialisation of seqan3::type_list.
+template <typename... ts>
+inline constexpr bool is_type_list<seqan3::type_list<ts...>> = true;
+
+} // namespace bio::detail

--- a/include/bio/seq_io/misc.hpp
+++ b/include/bio/seq_io/misc.hpp
@@ -22,6 +22,6 @@ namespace bio::seq_io
 
 //!\brief Default fields for seqan3::seq_io::reader_options.
 //!\ingroup seq_io
-inline constexpr auto default_field_ids = vtag<field::id, field::seq, field::qual>;
+inline auto default_field_ids = vtag<field::id, field::seq, field::qual>;
 
 } // namespace bio::seq_io

--- a/include/bio/seq_io/reader_options.hpp
+++ b/include/bio/seq_io/reader_options.hpp
@@ -7,7 +7,7 @@
 // -----------------------------------------------------------------------------------------------------
 
 /*!\file
- * \brief Provides bio::seq_io::reader_options and various field type .
+ * \brief Provides bio::seq_io::reader_options and various field_types definitions.
  * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
  */
 
@@ -23,8 +23,12 @@
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/phred63.hpp>
 #include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/utility/type_list/traits.hpp>
 #include <seqan3/utility/views/to.hpp>
 
+#include <bio/detail/concept.hpp>
+#include <bio/detail/misc.hpp>
+#include <bio/detail/range.hpp>
 #include <bio/format/fasta.hpp>
 #include <bio/misc.hpp>
 #include <bio/seq_io/misc.hpp>
@@ -35,6 +39,11 @@ namespace bio::seq_io
 {
 
 /*!\addtogroup seq_io
+ * \{
+ */
+
+/*!\name Pre-defined field types
+ * \brief These can be used to configure the behaviour of the bio::seq_io::reader via bio::seq_io::reader_options.
  * \{
  */
 
@@ -54,7 +63,7 @@ namespace bio::seq_io
 template <bio::ownership   ownership   = bio::ownership::shallow,
           seqan3::alphabet seq_alph_t  = seqan3::dna5,
           seqan3::alphabet qual_alph_t = seqan3::phred63>
-inline constexpr auto field_types = []()
+inline auto field_types = []()
 {
     if constexpr (ownership == bio::ownership::deep)
     {
@@ -81,7 +90,7 @@ inline constexpr auto field_types = []()
  *
  * Configures a shallow record where sequence data is seqan3::dna5 and quality data is seqan3::phred63.
  */
-inline constexpr auto field_types_dna = field_types<>;
+inline auto field_types_dna = field_types<>;
 
 /*!\brief The field types for reading protein data.
  * \tparam ownership Return shallow or deep types.
@@ -89,14 +98,14 @@ inline constexpr auto field_types_dna = field_types<>;
  *
  * Configures a shallow record where sequence data is seqan3::aa27 and quality data is seqan3::phred63.
  */
-inline constexpr auto field_types_protein = field_types<ownership::shallow, seqan3::aa27>;
+inline auto field_types_protein = field_types<ownership::shallow, seqan3::aa27>;
 
 /*!\brief The field types for reading any data.
  * \details
  *
  * Configures a shallow record where sequence and quality data are plain characters.
  */
-inline constexpr auto field_types_char = field_types<ownership::shallow, char, char>;
+inline auto field_types_char = field_types<ownership::shallow, char, char>;
 
 /*!\brief The field types for raw I/O.
  * \details
@@ -106,15 +115,17 @@ inline constexpr auto field_types_char = field_types<ownership::shallow, char, c
  * ATTENTION: The exact content of this byte-span depends on the format and is likely not
  * compatible between formats. Use at your own risk!
  */
-inline constexpr auto field_types_raw =
-  ttag<std::span<std::byte const>, std::span<std::byte const>, std::span<std::byte const>>;
+inline auto field_types_raw = ttag<std::span<std::byte const>, std::span<std::byte const>, std::span<std::byte const>>;
 // TODO use seqan3::list_traits::repeat as soon as available
 
-/*!\brief Options that can be used to configure the behaviour of seqan3::am_io::reader.
+//!\}
+//!\}
+
+/*!\brief Options that can be used to configure the behaviour of seqan3::seq_io::reader.
  * \tparam field_ids_t   Type of the field_ids member (usually deduced).
  * \tparam field_types_t Type of the field_types member (usually deduced).
  * \tparam formats_t     Type of the formats member (usually deduced).
- *
+ * \ingroup seq_io
  * \details
  *
  * By default, the reader options assume DNA data. You can select bio::seq_io::field_types_protein to
@@ -149,13 +160,32 @@ inline constexpr auto field_types_raw =
  * a std::string:
  *
  * \snippet test/snippet/seq_io/seq_io_reader_options.cpp example_advanced2
+ *
+ * ### Field type specific restrictions
+ *
+ * This section is only relevant if you specify the #field_types member manually, i.e. if you
+ * change the field_types but do not use one of the predefined tags.
+ *
+ * 1. bio::field::id
+ *   * any back-insertable range over the `char` alphabet (copy of elements returned)
+ *   * std::string_view (view into a buffer is returned)
+ * 2. bio::field::seq
+ *   * any back-insertable range over the `char` alphabet (copy of elements returned)
+ *   * any back-insertable range over a seqan3::alphabet (elements are transformed via seqan3::views::char_strictly_to)
+ *   * std::string_view (view into a buffer is returned)
+ *   * a std::ranges::transform_view defined on a std::string_view (transformation view is returned)
+ * 3. bio::field::qual
+ *   * any back-insertable range over the `char` alphabet (copy of elements returned)
+ *   * any back-insertable range over a seqan3::alphabet (elements are transformed via seqan3::views::char_strictly_to)
+ *   * std::string_view (view into a buffer is returned)
+ *   * a std::ranges::transform_view defined on a std::string_view (transformation view is returned)
  */
-template <typename field_ids_t   = std::remove_cvref_t<decltype(default_field_ids)>,
-          typename field_types_t = std::remove_cvref_t<decltype(field_types_dna)>,
+template <typename field_ids_t   = decltype(default_field_ids),
+          typename field_types_t = decltype(field_types_dna),
           typename formats_t     = seqan3::type_list<fasta>>
 struct reader_options
 {
-    /*!\brief The fields that shall be contained in each record; a seqan3::tag over bio::field.
+    /*!\brief The fields that shall be contained in each record; a bio::vtag over bio::field.
      * \details
      *
      * It is usually not necessary to change this.
@@ -163,19 +193,19 @@ struct reader_options
      */
     field_ids_t field_ids = default_field_ids;
 
-    /*!\brief The types corresponding to each field; a ttag over the types.
+    /*!\brief The types corresponding to each field; a bio::ttag over the types.
      *
      * \details
      *
-     * See seqan3::am_io::reader for an overview of the supported field/type combinations.
+     * See seqan3::seq_io::reader for an overview of the supported field/type combinations.
      */
     field_types_t field_types = field_types_dna;
 
-    /*!\brief The formats that input files can take; a ttag over the types.
+    /*!\brief The formats that input files can take; a bio::ttag over the types.
      *
      * \details
      *
-     * See seqan3::am_io::reader for an overview of the the supported formats.
+     * See seqan3::seq_io::reader for an overview of the the supported formats.
      */
     formats_t formats = ttag<fasta>;
 
@@ -185,9 +215,42 @@ struct reader_options
     //!\brief Truncate IDs at first whitespace.
     bool truncate_ids = false;
 
-    // TODO static_assert
-};
+private:
+    static_assert(detail::is_fields_tag<field_ids_t>, "field_ids must be a bio::vtag over bio::field.");
 
-//!\}
+    static_assert(detail::is_type_list<field_types_t>, "field_types must be a bio::ttag / seqan3::type_list.");
+
+    static_assert(detail::is_type_list<formats_t>, "formats must be a bio::ttag / seqan3::type_list.");
+
+    static_assert(field_ids_t::size == seqan3::list_traits::size<field_types_t>,
+                  "field_ids and field_types must have the same size.");
+
+    //!\brief Type of the record.
+    using record_t = detail::record_from_typelist<field_ids_t, field_types_t>;
+
+    static_assert(
+      detail::lazy_concept_checker([]<typename rec_t = record_t>(auto) requires(
+        !field_ids_t::contains(field::id) || detail::back_insertable_with<record_element_t<field::id, rec_t>, char> ||
+        std::same_as<std::string_view, record_element_t<field::id, rec_t>>) { return std::true_type{}; }),
+      "Requirements for the field-type of the ID-field not met. See documentation for bio::seq_io::reader_options.");
+
+    static_assert(
+      detail::lazy_concept_checker([]<typename rec_t = record_t>(auto) requires(
+        !field_ids_t::contains(field::seq) ||
+        (detail::back_insertable<record_element_t<field::seq, rec_t>> &&
+         seqan3::alphabet<std::ranges::range_reference_t<record_element_t<field::seq, rec_t>>>) ||
+        std::same_as<std::string_view, record_element_t<field::seq, rec_t>> ||
+        detail::transform_view_on_string_view<record_element_t<field::seq, rec_t>>) { return std::true_type{}; }),
+      "Requirements for the field-type of the SEQ-field not met. See documentation for bio::seq_io::reader_options.");
+
+    static_assert(
+      detail::lazy_concept_checker([]<typename rec_t = record_t>(auto) requires(
+        !field_ids_t::contains(field::qual) ||
+        (detail::back_insertable<record_element_t<field::qual, rec_t>> &&
+         seqan3::alphabet<std::ranges::range_reference_t<record_element_t<field::qual, rec_t>>>) ||
+        std::same_as<std::string_view, record_element_t<field::qual, rec_t>> ||
+        detail::transform_view_on_string_view<record_element_t<field::qual, rec_t>>) { return std::true_type{}; }),
+      "Requirements for the field-type of the QUAL-field not met. See documentation for bio::seq_io::reader_options.");
+};
 
 } // namespace bio::seq_io

--- a/test/unit/record_test.cpp
+++ b/test/unit/record_test.cpp
@@ -69,6 +69,12 @@ TEST_F(record, definition_tuple_traits)
     EXPECT_TRUE(seqan3::tuple_like<record_type>);
 }
 
+TEST_F(record, record_element)
+{
+    EXPECT_TRUE((std::is_same_v<bio::record_element_t<bio::field::id, record_type>, std::string>));
+    EXPECT_TRUE((std::is_same_v<bio::record_element_t<bio::field::seq, record_type>, seqan3::dna4_vector>));
+}
+
 TEST_F(record, construction)
 {
     [[maybe_unused]] record_type r{"MY ID", "ACGT"_dna4};

--- a/test/unit/seq_io/seq_io_reader_test.cpp
+++ b/test/unit/seq_io/seq_io_reader_test.cpp
@@ -259,3 +259,9 @@ TEST(seq_io_reader, decompression_stream)
     }
     EXPECT_EQ(count, 5);
 }
+
+// The following neads to cause a static assertion
+// TEST(seq_io_reader, option_fail)
+// {
+//     bio::seq_io::reader_options opt{.field_types = bio::ttag<int, int, int>};
+// }


### PR DESCRIPTION
@smehringer This is how we can enforce the requirements on the field_types and other members of the options.

Since concept checks are lazy-evaluated when constraining something but not lazy-evaluated when in a `static_assert` or `if constexpr`, I had to add some metaprogramming voodoo. The `overloaded` template is really useful in general though, I am surprised we didn't have that in SeqAn3, yet. (or maybe I was just too stupid to find it)

If you have any questions, please let me know!