### PR TITLE
various smaller changes

### DIFF
--- a/include/bio/detail/range.hpp
+++ b/include/bio/detail/range.hpp
@@ -73,13 +73,24 @@ concept vector_like = std::ranges::random_access_range<rng_t> && std::ranges::si
 };
 
 //!\brief Helper for bio::detail::transform_view_on_string_view.
-template <typename fun_t>
+template <std::regular_invocable<char> fun_t>
 void transform_view_on_string_view_impl(std::ranges::transform_view<std::string_view, fun_t> &)
+{}
+
+//!\brief Helper for bio::detail::transform_view_on_string_view.
+template <std::regular_invocable<char> fun1_t, std::regular_invocable<char> fun2_t>
+void transform_view_on_string_view_impl(
+  std::ranges::transform_view<std::ranges::transform_view<std::string_view, fun1_t>, fun2_t> &)
 {}
 
 /*!\interface   bio::detail::transform_view_on_string_view <>
  * \tparam t    The query type to check.
- * \brief       std::ranges::transform_view<std::string_view, fun_t> where fun_t is any valid functor type.
+ * \brief       Whether a type is a transform view (possibly nested) over std::string_view.
+ *
+ * Types must be one of:
+ *   1. std::ranges::transform_view<std::string_view, fun_t>  && std::regular_invocable<fun_t, char>
+ *   2. std::ranges::transform_view<std::ranges::transform_view<std::string_view, fun1_t>, fun2_t> &&
+ * std::regular_invocable<fun1_t, char> && std::regular_invocable<fun2_t, char>
  */
 //!\cond
 template <typename t>

--- a/include/bio/detail/reader_base.hpp
+++ b/include/bio/detail/reader_base.hpp
@@ -73,7 +73,7 @@ public:
      * \{
      */
     //!\brief The type of the record, a specialisation of bio::record; acts as a tuple of the selected field types.
-    using record_type = detail::record_from_typelist<decltype(options_t::field_ids), decltype(options_t::field_types)>;
+    using record_type = record<decltype(options_t::field_ids), decltype(options_t::field_types)>;
     //!\brief The iterator type of this view (an input iterator).
     using iterator    = detail::in_file_iterator<reader_base>;
     //!\brief The type returned by end().

--- a/include/bio/format/bcf_input_handler.hpp
+++ b/include/bio/format/bcf_input_handler.hpp
@@ -499,7 +499,7 @@ private:
     //!\brief The fields that this format supports [the base class accesses this type].
     using format_fields   = std::remove_cvref_t<decltype(var_io::default_field_ids)>;
     //!\brief Type of the raw record.
-    using raw_record_type = detail::record_from_typelist<format_fields, decltype(var_io::field_types_raw)>;
+    using raw_record_type = record<format_fields, decltype(var_io::field_types_raw)>;
 
     //!\brief The raw record.
     raw_record_type raw_record;

--- a/include/bio/format/bcf_input_handler.hpp
+++ b/include/bio/format/bcf_input_handler.hpp
@@ -21,8 +21,7 @@
 #include <string_view>
 #include <vector>
 
-// #include <seqan3/alphabet/views/char_strictly_to.hpp>
-#include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/char_strictly_to.hpp>
 #include <seqan3/core/debug_stream.hpp> //TODO evaluate if there is a better solution
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/range/type_traits.hpp>

--- a/include/bio/format/fasta_input_handler.hpp
+++ b/include/bio/format/fasta_input_handler.hpp
@@ -102,7 +102,7 @@ private:
     //!\brief The fields that this format supports [the base class accesses this type].
     using format_fields     = vtag_t<field::id, field::seq>;
     //!\brief Type of the raw record.
-    using raw_record_type   = record<format_fields, std::string_view, std::string_view>;
+    using raw_record_type   = record<format_fields, seqan3::type_list<std::string_view, std::string_view>>;
     //!\brief Type of the low-level iterator.
     using lowlevel_iterator = detail::plaintext_input_iterator<plain_io::record_kind::line>;
 

--- a/include/bio/format/format_input_handler.hpp
+++ b/include/bio/format/format_input_handler.hpp
@@ -17,7 +17,7 @@
 #include <string_view>
 #include <vector>
 
-#include <seqan3/alphabet/views/char_to.hpp> // TODO replace with char_strictly_to
+#include <seqan3/alphabet/views/char_strictly_to.hpp>
 
 #include <bio/detail/charconv.hpp>
 #include <bio/detail/concept.hpp>
@@ -101,7 +101,19 @@ private:
     static void parse_field_aux(std::string_view const                                 in,
                                 std::ranges::transform_view<std::string_view, fun_t> & parsed_field)
     {
-        parsed_field = std::ranges::transform_view<std::string_view, fun_t>{in, fun_t{}};
+        parsed_field = {in, fun_t{}};
+    }
+
+    //!\brief Parsing into transformed string views.
+    template <typename fun1_t, typename fun2_t>
+    static void parse_field_aux(
+      std::string_view const                                                                       in,
+      std::ranges::transform_view<std::ranges::transform_view<std::string_view, fun1_t>, fun2_t> & parsed_field)
+    {
+        parsed_field = {
+          {in, fun1_t{}},
+          fun2_t{          }
+        };
     }
 
     //!\brief Parse into string-like types.
@@ -119,7 +131,7 @@ private:
     {
         using target_alph_type = std::ranges::range_value_t<parsed_field_t>;
         //         detail::sized_range_copy(in | seqan3::views::char_strictly_to<target_alph_type>,
-        detail::sized_range_copy(in | seqan3::views::char_to<target_alph_type>, parsed_field);
+        detail::sized_range_copy(in | seqan3::views::char_strictly_to<target_alph_type>, parsed_field);
     }
 
     //!\brief Parse into a numerical type.

--- a/include/bio/format/vcf_input_handler.hpp
+++ b/include/bio/format/vcf_input_handler.hpp
@@ -21,8 +21,7 @@
 #include <string_view>
 #include <vector>
 
-// #include <seqan3/alphabet/views/char_strictly_to.hpp>
-#include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/char_strictly_to.hpp>
 #include <seqan3/core/debug_stream.hpp> //TODO evaluate if there is a better solution
 #include <seqan3/core/debug_stream/detail/to_string.hpp>
 #include <seqan3/core/range/type_traits.hpp>
@@ -38,6 +37,7 @@
 #include <bio/var_io/header.hpp>
 #include <bio/var_io/misc.hpp>
 #include <bio/var_io/reader_options.hpp>
+
 namespace bio
 {
 

--- a/include/bio/format/vcf_input_handler.hpp
+++ b/include/bio/format/vcf_input_handler.hpp
@@ -57,7 +57,7 @@ namespace bio
  *
  * | Member          | Type    | Default | Description                                                      |
  * |-----------------|---------|---------|------------------------------------------------------------------|
- * |`print_warnings` |`bool`   | `false` | Whether to print non-critical warngings to seqan3::debug_stream  |
+ * |`print_warnings` |`bool`   | `false` | Whether to print non-critical warnings to seqan3::debug_stream   |
  *
  * ### Performance
  *
@@ -100,12 +100,12 @@ private:
      * \{
      */
     //!\brief The fields that this format supports [the base class accesses this type].
-    using format_fields   = decltype(var_io::default_field_ids);
+    using format_fields = decltype(var_io::default_field_ids);
     //!\brief Type of the raw record.
-    using raw_record_type = detail::record_from_typelist<
-      format_fields,
-      seqan3::list_traits::concat<seqan3::list_traits::repeat<format_fields::size - 1, std::string_view>,
-                                  seqan3::type_list<var_io::record_private_data>>>;
+    using raw_record_type =
+      record<format_fields,
+             seqan3::list_traits::concat<seqan3::list_traits::repeat<format_fields::size - 1, std::string_view>,
+                                         seqan3::type_list<var_io::record_private_data>>>;
 
     //!\brief Type of the low-level iterator.
     using lowlevel_iterator = detail::plaintext_input_iterator<plain_io::record_kind::line_and_fields>;

--- a/include/bio/misc.hpp
+++ b/include/bio/misc.hpp
@@ -117,7 +117,7 @@ struct vtag_t<v, more_vs...>
  * \snippet test/snippet/snippet_tag.cpp vtag
  */
 template <auto... vs>
-inline constexpr vtag_t<vs...> vtag{};
+inline constinit vtag_t<vs...> vtag{};
 
 //-----------------------------------------------------------------------------
 // ttag
@@ -138,7 +138,7 @@ inline constexpr vtag_t<vs...> vtag{};
  * \snippet test/snippet/snippet_tag.cpp ttag
  */
 template <typename type, typename... more_types>
-inline constexpr seqan3::type_list<type, more_types...> ttag{};
+inline constinit seqan3::type_list<type, more_types...> ttag{};
 
 } // namespace bio
 

--- a/include/bio/seq_io/misc.hpp
+++ b/include/bio/seq_io/misc.hpp
@@ -22,6 +22,6 @@ namespace bio::seq_io
 
 //!\brief Default fields for seqan3::seq_io::reader_options.
 //!\ingroup seq_io
-inline auto default_field_ids = vtag<field::id, field::seq, field::qual>;
+inline constinit auto default_field_ids = vtag<field::id, field::seq, field::qual>;
 
 } // namespace bio::seq_io

--- a/include/bio/seq_io/reader.hpp
+++ b/include/bio/seq_io/reader.hpp
@@ -21,7 +21,7 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/phred63.hpp>
-#include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/char_strictly_to.hpp>
 #include <seqan3/utility/views/to.hpp>
 
 #include <bio/detail/reader_base.hpp>

--- a/include/bio/seq_io/reader_options.hpp
+++ b/include/bio/seq_io/reader_options.hpp
@@ -63,7 +63,7 @@ namespace bio::seq_io
 template <bio::ownership   ownership   = bio::ownership::shallow,
           seqan3::alphabet seq_alph_t  = seqan3::dna5,
           seqan3::alphabet qual_alph_t = seqan3::phred63>
-inline auto field_types = []()
+inline constinit auto field_types = []()
 {
     if constexpr (ownership == bio::ownership::deep)
     {
@@ -90,7 +90,7 @@ inline auto field_types = []()
  *
  * Configures a shallow record where sequence data is seqan3::dna5 and quality data is seqan3::phred63.
  */
-inline auto field_types_dna = field_types<>;
+inline constinit auto field_types_dna = field_types<>;
 
 /*!\brief The field types for reading protein data.
  * \tparam ownership Return shallow or deep types.
@@ -98,14 +98,14 @@ inline auto field_types_dna = field_types<>;
  *
  * Configures a shallow record where sequence data is seqan3::aa27 and quality data is seqan3::phred63.
  */
-inline auto field_types_protein = field_types<ownership::shallow, seqan3::aa27>;
+inline constinit auto field_types_protein = field_types<ownership::shallow, seqan3::aa27>;
 
 /*!\brief The field types for reading any data.
  * \details
  *
  * Configures a shallow record where sequence and quality data are plain characters.
  */
-inline auto field_types_char = field_types<ownership::shallow, char, char>;
+inline constinit auto field_types_char = field_types<ownership::shallow, char, char>;
 
 /*!\brief The field types for raw I/O.
  * \details
@@ -115,7 +115,8 @@ inline auto field_types_char = field_types<ownership::shallow, char, char>;
  * ATTENTION: The exact content of this byte-span depends on the format and is likely not
  * compatible between formats. Use at your own risk!
  */
-inline auto field_types_raw = ttag<std::span<std::byte const>, std::span<std::byte const>, std::span<std::byte const>>;
+inline constinit auto field_types_raw =
+  ttag<std::span<std::byte const>, std::span<std::byte const>, std::span<std::byte const>>;
 // TODO use seqan3::list_traits::repeat as soon as available
 
 //!\}

--- a/include/bio/seq_io/reader_options.hpp
+++ b/include/bio/seq_io/reader_options.hpp
@@ -22,7 +22,7 @@
 #include <seqan3/alphabet/concept.hpp>
 #include <seqan3/alphabet/nucleotide/dna5.hpp>
 #include <seqan3/alphabet/quality/phred63.hpp>
-#include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/alphabet/views/char_strictly_to.hpp>
 #include <seqan3/utility/type_list/traits.hpp>
 #include <seqan3/utility/views/to.hpp>
 
@@ -34,7 +34,7 @@
 #include <bio/seq_io/misc.hpp>
 #include <bio/stream/transparent_istream.hpp>
 
-// TODO replace seqan3::views::char_to with seqan3::views::char_strictly_to
+// TODO replace seqan3::views::char_strictly_to with seqan3::views::char_strictly_to
 namespace bio::seq_io
 {
 
@@ -76,10 +76,10 @@ inline constinit auto field_types = []()
         return ttag<std::string_view,
                     std::conditional_t<std::same_as<seq_alph_t, char>,
                                        std::string_view,
-                                       decltype(std::string_view{} | seqan3::views::char_to<seq_alph_t>)>,
+                                       decltype(std::string_view{} | seqan3::views::char_strictly_to<seq_alph_t>)>,
                     std::conditional_t<std::same_as<qual_alph_t, char>,
                                        std::string_view,
-                                       decltype(std::string_view{} | seqan3::views::char_to<qual_alph_t>)>>;
+                                       decltype(std::string_view{} | seqan3::views::char_strictly_to<qual_alph_t>)>>;
     }
 }();
 
@@ -223,8 +223,7 @@ private:
 
     static_assert(detail::is_type_list<formats_t>, "formats must be a bio::ttag / seqan3::type_list.");
 
-    static_assert(field_ids_t::size == seqan3::list_traits::size<field_types_t>,
-                  "field_ids and field_types must have the same size.");
+    static_assert(field_ids_t::size == field_types_t::size(), "field_ids and field_types must have the same size.");
 
     //!\brief Type of the record.
     using record_t = record<field_ids_t, field_types_t>;

--- a/include/bio/seq_io/reader_options.hpp
+++ b/include/bio/seq_io/reader_options.hpp
@@ -227,7 +227,7 @@ private:
                   "field_ids and field_types must have the same size.");
 
     //!\brief Type of the record.
-    using record_t = detail::record_from_typelist<field_ids_t, field_types_t>;
+    using record_t = record<field_ids_t, field_types_t>;
 
     static_assert(
       detail::lazy_concept_checker([]<typename rec_t = record_t>(auto) requires(

--- a/include/bio/var_io/misc.hpp
+++ b/include/bio/var_io/misc.hpp
@@ -239,7 +239,7 @@ struct genotypes_vcf
 
 //!\brief Default fields for bio::var_io::reader_options.
 //!\ingroup var_io
-inline constexpr auto default_field_ids = vtag<field::chrom,
+inline constinit auto default_field_ids = vtag<field::chrom,
                                                field::pos,
                                                field::id,
                                                field::ref,

--- a/include/bio/var_io/reader_options.hpp
+++ b/include/bio/var_io/reader_options.hpp
@@ -84,7 +84,7 @@ namespace bio::var_io
  * Since some elements in the record are views, it may not be possible and/or safe to change all values.
  */
 template <ownership own = ownership::shallow>
-inline constexpr auto field_types_bcf_style =
+inline constinit auto field_types_bcf_style =
   ttag<int32_t,                                                             // field::chrom,
        int32_t,                                                             // field::pos,
        std::string_view,                                                    // field::id,
@@ -108,7 +108,7 @@ inline constexpr auto field_types_bcf_style =
  * that are otherwise not modifiable (e.g. views).
  */
 template <>
-inline constexpr auto field_types_bcf_style<ownership::deep> =
+inline constinit auto field_types_bcf_style<ownership::deep> =
   ttag<int32_t,                                            // field::chrom,
        int32_t,                                            // field::pos,
        std::string,                                        // field::id,
@@ -138,7 +138,7 @@ inline constexpr auto field_types_bcf_style<ownership::deep> =
  * Since some elements in the record are views, it may not be possible and/or safe to change all values.
  */
 template <ownership own = ownership::shallow>
-inline constexpr auto field_types_vcf_style =
+inline constinit auto field_types_vcf_style =
   ttag<std::string_view,                                                    // field::chrom,
        int32_t,                                                             // field::pos,
        std::string_view,                                                    // field::id,
@@ -158,7 +158,7 @@ inline constexpr auto field_types_vcf_style =
  * The same as bio::var_io::field_types_vcf_style, but with self-contained records.
  */
 template <>
-inline constexpr auto field_types_vcf_style<ownership::deep> =
+inline constinit auto field_types_vcf_style<ownership::deep> =
   ttag<std::string,                                // field::chrom
        int32_t,                                    // field::pos
        std::string,                                // field::id
@@ -172,7 +172,7 @@ inline constexpr auto field_types_vcf_style<ownership::deep> =
 
 //!\brief Every field is configured as a std::span of std::byte (this enables "raw" io).
 //!\ingroup var_io
-inline constexpr auto field_types_raw =
+inline constinit auto field_types_raw =
   seqan3::list_traits::concat<seqan3::list_traits::repeat<default_field_ids.size - 1, std::span<std::byte const>>,
                               seqan3::type_list<var_io::record_private_data>>{};
 
@@ -229,8 +229,8 @@ inline constexpr auto field_types_raw =
  *     * The second subelement must range-of-range over bio::var_io::dynamic_type and both
  * range-dimensions need to support back-insertion.
  */
-template <typename field_ids_t   = std::remove_cvref_t<decltype(default_field_ids)>,
-          typename field_types_t = std::remove_cvref_t<decltype(field_types_bcf_style<ownership::shallow>)>,
+template <typename field_ids_t   = decltype(default_field_ids),
+          typename field_types_t = decltype(field_types_bcf_style<ownership::shallow>),
           typename formats_t     = seqan3::type_list<vcf, bcf>>
 struct reader_options
 {

--- a/test/unit/format/bcf_input_test.cpp
+++ b/test/unit/format/bcf_input_test.cpp
@@ -96,8 +96,8 @@ void field_types_bcf_style()
     std::istringstream       istream{static_cast<std::string>(example_from_spec_bcf)};
     bio::transparent_istream str{istream};
 
-    using record_t = bio::detail::record_from_typelist<decltype(bio::var_io::default_field_ids),
-                                                       decltype(bio::var_io::field_types_bcf_style<own>)>;
+    using record_t =
+      bio::record<decltype(bio::var_io::default_field_ids), decltype(bio::var_io::field_types_bcf_style<own>)>;
 
     bio::format_input_handler<bio::bcf> handler{str, bio::var_io::reader_options{}};
 
@@ -150,8 +150,8 @@ void field_types_vcf_style()
     std::istringstream       istream{static_cast<std::string>(example_from_spec_bcf)};
     bio::transparent_istream str{istream};
 
-    using record_t = bio::detail::record_from_typelist<decltype(bio::var_io::default_field_ids),
-                                                       decltype(bio::var_io::field_types_vcf_style<own>)>;
+    using record_t =
+      bio::record<decltype(bio::var_io::default_field_ids), decltype(bio::var_io::field_types_vcf_style<own>)>;
 
     bio::format_input_handler<bio::bcf> handler{str, bio::var_io::reader_options{}};
 

--- a/test/unit/format/fasta_input_test.cpp
+++ b/test/unit/format/fasta_input_test.cpp
@@ -29,9 +29,9 @@ using std::literals::string_view_literals::operator""sv;
 
 struct read : public ::testing::Test
 {
-    using default_rec_t = bio::record<bio::vtag_t<bio::field::id, bio::field::seq>,
-                                      std::string_view,
-                                      decltype(std::string_view{} | seqan3::views::char_to<seqan3::dna5>)>;
+    using default_rec_t = bio::record<
+      bio::vtag_t<bio::field::id, bio::field::seq>,
+      seqan3::type_list<std::string_view, decltype(std::string_view{} | seqan3::views::char_to<seqan3::dna5>)>>;
 
     std::vector<std::string> ids{
       {"ID1"},
@@ -58,7 +58,7 @@ struct read : public ::testing::Test
 
         bio::format_input_handler<bio::fasta> input_handler{istream};
 
-        bio::record<bio::vtag_t<bio::field::id, bio::field::seq>, id_t, seq_t> rec;
+        bio::record<bio::vtag_t<bio::field::id, bio::field::seq>, seqan3::type_list<id_t, seq_t>> rec;
 
         for (unsigned i = 0; i < 3; ++i)
         {

--- a/test/unit/format/fasta_input_test.cpp
+++ b/test/unit/format/fasta_input_test.cpp
@@ -29,9 +29,10 @@ using std::literals::string_view_literals::operator""sv;
 
 struct read : public ::testing::Test
 {
-    using default_rec_t = bio::record<
-      bio::vtag_t<bio::field::id, bio::field::seq>,
-      seqan3::type_list<std::string_view, decltype(std::string_view{} | seqan3::views::char_to<seqan3::dna5>)>>;
+    using default_rec_t =
+      bio::record<bio::vtag_t<bio::field::id, bio::field::seq>,
+                  seqan3::type_list<std::string_view,
+                                    decltype(std::string_view{} | seqan3::views::char_strictly_to<seqan3::dna5>)>>;
 
     std::vector<std::string> ids{
       {"ID1"},
@@ -65,7 +66,7 @@ struct read : public ::testing::Test
             input_handler.parse_next_record_into(rec);
             if constexpr (std::same_as<std::ranges::range_value_t<seq_t>, char>)
             {
-                EXPECT_RANGE_EQ(rec.seq() | seqan3::views::char_to<seqan3::dna5>, seqs[i]);
+                EXPECT_RANGE_EQ(rec.seq() | seqan3::views::char_strictly_to<seqan3::dna5>, seqs[i]);
             }
             else
             {
@@ -83,7 +84,8 @@ struct read : public ::testing::Test
 
         /* views */
         do_read_test_impl<std::string_view, std::string_view>(input);
-        do_read_test_impl<std::string_view, decltype(std::string_view{} | seqan3::views::char_to<seqan3::dna5>)>(input);
+        do_read_test_impl<std::string_view,
+                          decltype(std::string_view{} | seqan3::views::char_strictly_to<seqan3::dna5>)>(input);
     }
 };
 
@@ -287,15 +289,16 @@ TEST_F(read, fail_no_seq)
     EXPECT_THROW(input_handler.parse_next_record_into(rec), bio::parse_error);
 }
 
-// TODO activate after switch to seqan3::views::char_strictly_to
-// TEST_F(read, fail_illegal_alphabet)
-// {
-//     std::string input{">foo\nFOOBAR\n"};
-//
-//     std::istringstream istream{input};
-//     bio::format_input_handler<bio::fasta> input_handler{istream};
-//     using rec_t = bio::record<bio::vtag_t<bio::field::id, bio::field::seq>, std::string_view,
-//     std::vector<seqan3::dna5>>; rec_t rec;
-//
-//     EXPECT_THROW(input_handler.parse_next_record_into(rec), seqan3::invalid_char_assignment);
-// }
+TEST_F(read, fail_illegal_alphabet)
+{
+    std::string input{">foo\nFOOBAR\n"};
+
+    std::istringstream                    istream{input};
+    bio::format_input_handler<bio::fasta> input_handler{istream};
+    using rec_t = bio::record<bio::vtag_t<bio::field::id, bio::field::seq>,
+                              seqan3::type_list<std::string_view, std::vector<seqan3::dna5>>>;
+
+    rec_t rec;
+
+    EXPECT_THROW(input_handler.parse_next_record_into(rec), seqan3::invalid_char_assignment);
+}

--- a/test/unit/format/vcf_data.hpp
+++ b/test/unit/format/vcf_data.hpp
@@ -9,8 +9,8 @@
 #include <ranges>
 #include <string>
 
-// #include <seqan3/alphabet/views/char_to.hpp>
-#include <seqan3/alphabet/views/char_to.hpp>
+#include <seqan3/core/debug_stream.hpp>
+#include <seqan3/alphabet/views/char_strictly_to.hpp>
 #include <seqan3/utility/views/to.hpp>
 
 #include <bio/detail/magic_get.hpp>
@@ -202,7 +202,7 @@ R"(##fileformat=VCFv4.3
 //=============================================================================
 
 /* auxiliary stuff */
-using tf_view = decltype(std::string_view{} | seqan3::views::char_to<seqan3::dna5>);
+using tf_view = decltype(std::string_view{} | seqan3::views::char_strictly_to<seqan3::dna5>);
 
 bool operator==(tf_view const & lhs, tf_view const & rhs)
 {
@@ -237,9 +237,9 @@ template <bio::ownership own>
 auto make_ref(std::string_view const str)
 {
     if constexpr (own == bio::ownership::shallow)
-        return tf_view{str, {}};
+        return tf_view{{str, {}}, {}};
     else
-        return str | seqan3::views::char_to<seqan3::dna5> | seqan3::views::to<std::vector>;
+        return str | seqan3::views::char_strictly_to<seqan3::dna5> | seqan3::views::to<std::vector>;
 }
 
 template <bio::ownership own, typename int_t = int32_t>

--- a/test/unit/format/vcf_data.hpp
+++ b/test/unit/format/vcf_data.hpp
@@ -245,7 +245,7 @@ auto make_ref(std::string_view const str)
 template <bio::ownership own, typename int_t = int32_t>
 auto example_records_vcf_style()
 {
-    using record_t = bio::detail::record_from_typelist<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
+    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
                                  std::remove_cvref_t<decltype(bio::var_io::field_types_vcf_style<own>)>>;
 
     bio::var_io::record_private_data priv{};
@@ -269,7 +269,7 @@ auto example_records_vcf_style()
 template <bio::ownership own, typename int_t = int32_t>
 auto example_records_bcf_style()
 {
-    using record_t = bio::detail::record_from_typelist<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
+    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
                                  std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<own>)>>;
 
     bio::var_io::record_private_data priv{};

--- a/test/unit/format/vcf_input_test.cpp
+++ b/test/unit/format/vcf_input_test.cpp
@@ -20,8 +20,8 @@ void field_types_bcf_style()
 {
     std::istringstream istr{std::string{example_from_spec}};
 
-    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                                 std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<own>)>>;
+    using record_t =
+      bio::record<decltype(bio::var_io::default_field_ids), decltype(bio::var_io::field_types_bcf_style<own>)>;
 
     bio::format_input_handler<bio::vcf> handler{istr, bio::var_io::reader_options{}};
 
@@ -65,8 +65,8 @@ void field_types_vcf_style()
 {
     std::istringstream istr{std::string{example_from_spec}};
 
-    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                                 std::remove_cvref_t<decltype(bio::var_io::field_types_vcf_style<own>)>>;
+    using record_t =
+      bio::record<decltype(bio::var_io::default_field_ids), decltype(bio::var_io::field_types_vcf_style<own>)>;
 
     bio::format_input_handler<bio::vcf> handler{istr, bio::var_io::reader_options{}};
 
@@ -113,8 +113,8 @@ TEST(vcf, incomplete_header)
 
     std::istringstream istr{incomplete_header_before + example_from_spec_records};
 
-    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                                 std::remove_cvref_t<decltype(bio::var_io::field_types_vcf_style<>)>>;
+    using record_t =
+      bio::record<decltype(bio::var_io::default_field_ids), decltype(bio::var_io::field_types_vcf_style<>)>;
 
     bio::format_input_handler<bio::vcf> handler{istr, bio::var_io::reader_options{.print_warnings = false}};
 

--- a/test/unit/format/vcf_input_test.cpp
+++ b/test/unit/format/vcf_input_test.cpp
@@ -20,10 +20,8 @@ void field_types_bcf_style()
 {
     std::istringstream istr{std::string{example_from_spec}};
 
-    using record_t =
-      bio::detail::record_from_typelist<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                                        std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<own>)>>;
-    ;
+    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
+                                 std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<own>)>>;
 
     bio::format_input_handler<bio::vcf> handler{istr, bio::var_io::reader_options{}};
 
@@ -67,10 +65,8 @@ void field_types_vcf_style()
 {
     std::istringstream istr{std::string{example_from_spec}};
 
-    using record_t =
-      bio::detail::record_from_typelist<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                                        std::remove_cvref_t<decltype(bio::var_io::field_types_vcf_style<own>)>>;
-    ;
+    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
+                                 std::remove_cvref_t<decltype(bio::var_io::field_types_vcf_style<own>)>>;
 
     bio::format_input_handler<bio::vcf> handler{istr, bio::var_io::reader_options{}};
 
@@ -117,9 +113,8 @@ TEST(vcf, incomplete_header)
 
     std::istringstream istr{incomplete_header_before + example_from_spec_records};
 
-    using record_t =
-      bio::detail::record_from_typelist<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                                        std::remove_cvref_t<decltype(bio::var_io::field_types_vcf_style<>)>>;
+    using record_t = bio::record<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
+                                 std::remove_cvref_t<decltype(bio::var_io::field_types_vcf_style<>)>>;
 
     bio::format_input_handler<bio::vcf> handler{istr, bio::var_io::reader_options{.print_warnings = false}};
 

--- a/test/unit/record_test.cpp
+++ b/test/unit/record_test.cpp
@@ -55,7 +55,7 @@ TEST(fields, usage)
 struct record : public ::testing::Test
 {
     using ids         = bio::vtag_t<bio::field::id, bio::field::seq>;
-    using record_type = bio::record<ids, std::string, seqan3::dna4_vector>;
+    using record_type = bio::record<ids, seqan3::type_list<std::string, seqan3::dna4_vector>>;
 };
 
 TEST_F(record, definition_tuple_traits)
@@ -127,5 +127,7 @@ TEST_F(record, tie_record)
     auto        vec = "ACGT"_dna4;
 
     auto r = bio::tie_record(bio::vtag<bio::field::id, bio::field::seq>, s, vec);
-    EXPECT_TRUE((std::same_as<decltype(r), bio::record<record::ids, std::string &, std::vector<seqan3::dna4> &>>));
+    EXPECT_TRUE(
+      (std::same_as<decltype(r),
+                    bio::record<record::ids, seqan3::type_list<std::string &, std::vector<seqan3::dna4> &>>>));
 }

--- a/test/unit/var_io/var_io_reader_test.cpp
+++ b/test/unit/var_io/var_io_reader_test.cpp
@@ -62,10 +62,9 @@ TEST(var_io_reader, constructor1_just_filename)
 TEST(var_io_reader, constructor1_with_opts)
 {
     bio::var_io::reader_options opt{.field_types = bio::var_io::field_types_bcf_style<>};
-    using control_t =
-      bio::var_io::reader<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                          std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>)>,
-                          seqan3::type_list<bio::vcf, bio::bcf>>;
+    using control_t = bio::var_io::reader<decltype(bio::var_io::default_field_ids),
+                                          decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>),
+                                          seqan3::type_list<bio::vcf, bio::bcf>>;
 
     var_io_reader_filename_constructor(true, std::move(opt));
     EXPECT_TRUE((std::same_as<decltype(bio::var_io::reader{"", opt}), control_t>));
@@ -80,10 +79,9 @@ TEST(var_io_reader, constructor2_just_filename_direct_format)
 TEST(var_io_reader, constructor2_with_opts_direct_format)
 {
     bio::var_io::reader_options opt{.field_types = bio::var_io::field_types_bcf_style<>};
-    using control_t =
-      bio::var_io::reader<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                          std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>)>,
-                          seqan3::type_list<bio::vcf, bio::bcf>>;
+    using control_t = bio::var_io::reader<decltype(bio::var_io::default_field_ids),
+                                          decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>),
+                                          seqan3::type_list<bio::vcf, bio::bcf>>;
 
     var_io_reader_filename_constructor(false, bio::vcf{}, std::move(opt));
     EXPECT_TRUE((std::same_as<decltype(bio::var_io::reader{"", bio::vcf{}, opt}), control_t>));
@@ -101,10 +99,9 @@ TEST(var_io_reader, constructor2_with_opts_format_variant)
 {
     std::variant<bio::vcf, bio::bcf> var{};
     bio::var_io::reader_options      opt{.field_types = bio::var_io::field_types_bcf_style<>};
-    using control_t =
-      bio::var_io::reader<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                          std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>)>,
-                          seqan3::type_list<bio::vcf, bio::bcf>>;
+    using control_t = bio::var_io::reader<decltype(bio::var_io::default_field_ids),
+                                          decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>),
+                                          seqan3::type_list<bio::vcf, bio::bcf>>;
 
     var_io_reader_filename_constructor(false, var, std::move(opt));
     EXPECT_TRUE((std::same_as<decltype(bio::var_io::reader{"", var, std::move(opt)}), control_t>));
@@ -122,10 +119,9 @@ TEST(var_io_reader, constructor3_with_opts)
 {
     std::istringstream          str;
     bio::var_io::reader_options opt{.field_types = bio::var_io::field_types_bcf_style<>};
-    using control_t =
-      bio::var_io::reader<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                          std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>)>,
-                          seqan3::type_list<bio::vcf, bio::bcf>>;
+    using control_t = bio::var_io::reader<decltype(bio::var_io::default_field_ids),
+                                          decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>),
+                                          seqan3::type_list<bio::vcf, bio::bcf>>;
 
     EXPECT_NO_THROW((bio::var_io::reader{str, bio::vcf{}, opt}));
     EXPECT_TRUE((std::same_as<decltype(bio::var_io::reader{str, bio::vcf{}, opt}), control_t>));
@@ -143,10 +139,9 @@ TEST(var_io_reader, constructor4_with_opts)
 {
     std::istringstream          str;
     bio::var_io::reader_options opt{.field_types = bio::var_io::field_types_bcf_style<>};
-    using control_t =
-      bio::var_io::reader<std::remove_cvref_t<decltype(bio::var_io::default_field_ids)>,
-                          std::remove_cvref_t<decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>)>,
-                          seqan3::type_list<bio::vcf, bio::bcf>>;
+    using control_t = bio::var_io::reader<decltype(bio::var_io::default_field_ids),
+                                          decltype(bio::var_io::field_types_bcf_style<bio::ownership::shallow>),
+                                          seqan3::type_list<bio::vcf, bio::bcf>>;
 
     EXPECT_NO_THROW((bio::var_io::reader{std::move(str), bio::vcf{}, opt}));
     EXPECT_TRUE((std::same_as<decltype(bio::var_io::reader{std::move(str), bio::vcf{}, opt}), control_t>));

--- a/test/unit/var_io/var_io_reader_test.cpp
+++ b/test/unit/var_io/var_io_reader_test.cpp
@@ -231,10 +231,8 @@ TEST(var_io_reader, custom_field_types)
     std::istringstream  str{static_cast<std::string>(example_from_spec)};
     bio::var_io::reader reader{str, bio::vcf{}, opt};
 
-    EXPECT_TRUE(
-      (std::same_as<
-        std::ranges::range_value_t<decltype(reader)>,
-        bio::detail::record_from_typelist<decltype(bio::var_io::default_field_ids),
+    EXPECT_TRUE((std::same_as<std::ranges::range_value_t<decltype(reader)>,
+                              bio::record<decltype(bio::var_io::default_field_ids),
                                           decltype(bio::var_io::field_types_bcf_style<bio::ownership::deep>)>>));
 }
 


### PR DESCRIPTION
Some small stuff, including the revert of the seqan3::record you suggested.

This also add the concept checks to var_io::reader_options which is similar to map_io in complexity. Compile time for `var_io_reader_test` increases from 11.19s to 11.47s (median out of three each). And this is for a test that actually instantiates multiple different options whereas users usually only instantiate options once. So I think this is very negligible.