### PR TITLE
Various updates and fixes

### DIFF
--- a/.github/workflows/clang-format.yaml
+++ b/.github/workflows/clang-format.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo 'APT::Acquire::Retries "5";' | sudo tee -a /etc/apt/apt.conf.d/80-retries > /dev/null
           sudo wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo add-apt-repository --no-update --yes "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
+          sudo add-apt-repository --no-update --yes "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main"
           sudo apt-get update
 
       - name: Install CMake

--- a/include/bio/detail/concept.hpp
+++ b/include/bio/detail/concept.hpp
@@ -17,7 +17,7 @@
 
 #include <seqan3/alphabet/concept.hpp>
 
-#include <bio/platform.hpp>
+#include <bio/detail/utility.hpp>
 
 namespace bio::detail
 {
@@ -44,6 +44,30 @@ concept one_of = (std::same_as<t, ts> || ...);
 template <typename t>
 concept deliberate_alphabet = seqan3::alphabet<t> && !std::integral<std::remove_cvref_t<t>>;
 //!\endcond
+
+/*!\interface   bio::detail::decays_to <>
+ * \tparam t    The type to check.
+ * \brief       Shortcut for `std::same_as<std::decay_t<from_t>, to_t>`.
+ */
+//!\cond
+template <typename from_t, typename to_t>
+concept decays_to = std::same_as<std::decay_t<from_t>, to_t>;
+//!\endcond
+
+/*!\brief Pass this function a constrained functor that accepts one argument and returns std::true_type.
+ * \details
+ *
+ * See e.g. bio::seq_io::reader_options to see how this is used.
+ */
+constexpr bool lazy_concept_checker(auto fun)
+{
+    auto fallback = []<typename T = int>(auto)
+    {
+        return std::false_type{};
+    };
+    using ret_t = decltype(detail::overloaded{fallback, fun}(1));
+    return ret_t::value;
+}
 
 //!\}
 

--- a/include/bio/detail/in_file_iterator.hpp
+++ b/include/bio/detail/in_file_iterator.hpp
@@ -67,12 +67,12 @@ public:
     /*!\name Constructors, destructor and assignment.
      * \{
      */
-    in_file_iterator()                         = default;             //!< Defaulted.
-    in_file_iterator(in_file_iterator const &) = default;             //!< Defaulted.
-    in_file_iterator(in_file_iterator &&)      = default;             //!< Defaulted.
-    ~in_file_iterator()                        = default;             //!< Defaulted.
+    in_file_iterator()                                     = default; //!< Defaulted.
+    in_file_iterator(in_file_iterator const &)             = default; //!< Defaulted.
+    in_file_iterator(in_file_iterator &&)                  = default; //!< Defaulted.
+    ~in_file_iterator()                                    = default; //!< Defaulted.
     in_file_iterator & operator=(in_file_iterator const &) = default; //!< Defaulted.
-    in_file_iterator & operator=(in_file_iterator &&) = default;      //!< Defaulted.
+    in_file_iterator & operator=(in_file_iterator &&)      = default; //!< Defaulted.
 
     //!\brief Construct with reference to host.
     in_file_iterator(file_type & _host) noexcept : host{&_host} {}

--- a/include/bio/detail/magic_get.hpp
+++ b/include/bio/detail/magic_get.hpp
@@ -29,11 +29,7 @@ namespace bio::detail
  */
 //!\cond
 template <typename t>
-concept tuple_of_two = requires
-{
-    std::tuple_size<t>::value;
-}
-&&std::tuple_size<t>::value == 2;
+concept tuple_of_two = (requires { std::tuple_size<t>::value; }) && (std::tuple_size<t>::value == 2);
 
 //!\endcond
 
@@ -64,11 +60,12 @@ struct converts_to_any_lref
  * \brief       A aggregate type with exactly two elements.
  */
 //!\cond
+// clang-format off
 template <typename t>
-concept aggregate_of_two = std::is_aggregate_v<t> && requires
-{
-    t{converts_to_any_lref{}, converts_to_any_lref{}};
-} && !(requires { t{converts_to_any_lref{}, converts_to_any_lref{}, converts_to_any_lref{}}; });
+concept aggregate_of_two = std::is_aggregate_v<t> &&
+    (requires { t{converts_to_any_lref{}, converts_to_any_lref{}};                          }) &&
+   !(requires { t{converts_to_any_lref{}, converts_to_any_lref{}, converts_to_any_lref{}};  });
+// clang-format on
 //!\endcond
 
 /*!\interface   bio::detail::decomposable_into_two <>
@@ -114,5 +111,12 @@ auto & get_second(decomposable_into_two auto & val)
  */
 template <typename t>
 using second_elem_t = std::remove_cvref_t<decltype(get_second(std::declval<t &>()))>;
+
+//!\brief Overload of bio::detail::range_or_tuple_size for aggregates of two.
+//!\ingroup bio
+constexpr size_t range_or_tuple_size(aggregate_of_two auto &&)
+{
+    return 2;
+}
 
 } // namespace bio::detail

--- a/include/bio/detail/misc.hpp
+++ b/include/bio/detail/misc.hpp
@@ -71,29 +71,6 @@ void set_format(auto & format, std::filesystem::path const & file_name)
         throw unhandled_extension_error("No valid format found for this extension.");
 }
 
-//!\brief Wrapper to create an overload set of multiple functors.
-template <typename... functors>
-struct overloaded : functors...
-{
-    using functors::operator()...;
-};
-
-//!\brief Deduction guide for bio::detail::overloaded.
-template <typename... functors>
-overloaded(functors...) -> overloaded<functors...>;
-
-/*!\brief Pass this function a constrained functor that accepts one argument and returns std::true_type.
- * \details
- *
- * See e.g. bio::seq_io::reader_options to see how this is used.
- */
-constexpr bool lazy_concept_checker(auto fun)
-{
-    auto fallback = []<typename T = int>(auto) { return std::false_type{}; };
-    using ret_t   = decltype(detail::overloaded{fallback, fun}(1));
-    return ret_t::value;
-}
-
 //!\}
 
 } // namespace bio::detail

--- a/include/bio/detail/out_file_iterator.hpp
+++ b/include/bio/detail/out_file_iterator.hpp
@@ -75,17 +75,17 @@ public:
      * \{
      */
     //!\brief Default constructor.
-    constexpr out_file_iterator()                          = default;
+    constexpr out_file_iterator()                                      = default;
     //!\brief Copy constructor.
-    constexpr out_file_iterator(out_file_iterator const &) = default;
+    constexpr out_file_iterator(out_file_iterator const &)             = default;
     //!\brief Copy construction via assignment.
     constexpr out_file_iterator & operator=(out_file_iterator const &) = default;
     //!\brief Move constructor.
     constexpr out_file_iterator(out_file_iterator &&)                  = default;
     //!\brief Move assignment.
-    constexpr out_file_iterator & operator=(out_file_iterator &&) = default;
+    constexpr out_file_iterator & operator=(out_file_iterator &&)      = default;
     //!\brief Use default deconstructor.
-    ~out_file_iterator()                                          = default;
+    ~out_file_iterator()                                               = default;
 
     //!\brief Construct with reference to host.
     constexpr out_file_iterator(file_type & _host) noexcept : host{&_host} {}

--- a/include/bio/detail/range.hpp
+++ b/include/bio/detail/range.hpp
@@ -57,9 +57,13 @@ concept back_insertable =
 
 //!\brief A range whose value type is `char`.
 template <typename t>
-concept char_range = (std::ranges::forward_range<t> &&
-                      std::same_as<char, std::remove_cvref_t<std::ranges::range_value_t<t>>>) ||
-                     std::same_as<std::decay_t<t>, char const *>;
+concept char_range =
+  std::ranges::forward_range<t> && std::same_as<char, std::remove_cvref_t<std::ranges::range_value_t<t>>>;
+
+//!\brief A range whose value type is `char` or a C-String.
+template <typename t>
+concept char_range_or_cstring = char_range<t> || std::same_as < std::decay_t<t>,
+char const * > ;
 
 //!\brief A range whose value type is an integral type other than `char`.
 template <typename t>
@@ -154,6 +158,51 @@ void string_copy(std::string_view const in, out_string auto & out)
     else
         sized_range_copy(in, out);
 }
+
+// ----------------------------------------------------------------------------
+// to_string_view
+// ----------------------------------------------------------------------------
+
+//!\brief Turn something string-viewable into a std::string_view.
+constexpr std::string_view to_string_view(char const * const cstring)
+{
+    return std::string_view{cstring};
+}
+
+//!\overload
+template <char_range rng_t>
+    requires std::ranges::borrowed_range<rng_t> && std::ranges::contiguous_range<rng_t> &&
+      std::ranges::sized_range<rng_t>
+constexpr std::string_view to_string_view(rng_t && contig_range)
+{
+    return std::string_view{std::ranges::data(contig_range), std::ranges::size(contig_range)};
+}
+
+//!\overload
+constexpr std::string_view to_string_view(std::string_view const in)
+{
+    return in;
+}
+
+// ----------------------------------------------------------------------------
+// range_or_tuple_size
+// ----------------------------------------------------------------------------
+
+//!\brief Returns the size of the argument, either a range or a tuple.
+constexpr size_t range_or_tuple_size(std::ranges::forward_range auto && r)
+{
+    return std::ranges::distance(r);
+}
+
+//!\overload
+template <typename tuple_t>
+    requires(requires { typename std::tuple_size<std::remove_cvref_t<tuple_t>>::type; })
+constexpr size_t range_or_tuple_size(tuple_t)
+{
+    return std::tuple_size_v<tuple_t>;
+}
+
+// there is another overload for this in magic_get.hpp
 
 //!\}
 

--- a/include/bio/detail/reader_base.hpp
+++ b/include/bio/detail/reader_base.hpp
@@ -84,17 +84,17 @@ public:
      * \{
      */
     //!\brief Default constructor is explicitly deleted, you need to give a stream or file name.
-    reader_base()                    = delete;
+    reader_base()                                = delete;
     //!\brief Copy construction is explicitly deleted, because you can't have multiple access to the same file.
-    reader_base(reader_base const &) = delete;
+    reader_base(reader_base const &)             = delete;
     //!\brief Copy assignment is explicitly deleted, because you can't have multiple access to the same file.
     reader_base & operator=(reader_base const &) = delete;
     //!\brief Move construction is defaulted.
     reader_base(reader_base &&)                  = default;
     //!\brief Move assignment is defaulted.
-    reader_base & operator=(reader_base &&) = default;
+    reader_base & operator=(reader_base &&)      = default;
     //!\brief Destructor is defaulted.
-    ~reader_base()                          = default;
+    ~reader_base()                               = default;
 
     /*!\brief Construct from filename.
      * \param[in] filename  Path to the file you wish to open.

--- a/include/bio/detail/utility.hpp
+++ b/include/bio/detail/utility.hpp
@@ -1,0 +1,70 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2021, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2021, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2020-2021, deCODE Genetics
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/bio/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+/*!\file
+ * \brief Provides miscellaneous utilities.
+ * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <concepts>
+#include <filesystem>
+#include <ranges>
+#include <string>
+
+#include <seqan3/core/detail/template_inspection.hpp>
+#include <seqan3/utility/type_list/detail/type_list_algorithm.hpp>
+#include <seqan3/utility/type_list/type_list.hpp>
+
+#include <bio/exception.hpp>
+
+namespace bio::detail
+{
+
+/*!\addtogroup bio
+ * \{
+ */
+
+//!\brief Wrapper to create an overload set of multiple functors.
+template <typename... functors>
+struct overloaded : functors...
+{
+    using functors::operator()...;
+};
+
+//!\brief Deduction guide for bio::detail::overloaded.
+template <typename... functors>
+overloaded(functors...) -> overloaded<functors...>;
+//!\}
+
+//!\brief Can be included as a member to infer whether parent is in moved-from state.
+//!\ingroup bio
+struct move_tracker
+{
+    //!\brief Defaulted.
+    move_tracker() = default;
+
+    //!\brief Sets moved-from state.
+    move_tracker(move_tracker && rhs) { rhs.moved_from = true; }
+    //!\brief Sets moved-from state.
+    move_tracker & operator=(move_tracker && rhs)
+    {
+        rhs.moved_from = true;
+        return *this;
+    }
+
+    move_tracker(move_tracker const & rhs)             = default; //!< Defaulted.
+    move_tracker & operator=(move_tracker const & rhs) = default; //!< Defaulted.
+
+    //!\brief The state.
+    bool moved_from = false;
+};
+
+} // namespace bio::detail

--- a/include/bio/detail/views_eager_split.hpp
+++ b/include/bio/detail/views_eager_split.hpp
@@ -65,17 +65,17 @@ public:
      * \{
      */
     //!\brief Default construction.
-    eager_split_iterator()                                           = default;
+    eager_split_iterator()                                                       = default;
     //!\brief Copy construction.
-    constexpr eager_split_iterator(eager_split_iterator const & rhs) = default;
+    constexpr eager_split_iterator(eager_split_iterator const & rhs)             = default;
     //!\brief Move construction.
-    constexpr eager_split_iterator(eager_split_iterator && rhs)      = default;
+    constexpr eager_split_iterator(eager_split_iterator && rhs)                  = default;
     //!\brief Destruction.
-    ~eager_split_iterator()                                          = default;
+    ~eager_split_iterator()                                                      = default;
     //!\brief Copy assignment.
     constexpr eager_split_iterator & operator=(eager_split_iterator const & rhs) = default;
     //!\brief Move assignment.
-    constexpr eager_split_iterator & operator=(eager_split_iterator && rhs) = default;
+    constexpr eager_split_iterator & operator=(eager_split_iterator && rhs)      = default;
 
     //!\brief Constructing from the underlying seqan3::eager_split_view.
     constexpr eager_split_iterator(std::string_view const _urange, char const _delimiter, bool skip_quotes_) noexcept :
@@ -214,17 +214,17 @@ public:
      * \brief All standard functions are explicitly set to default.
      */
     //!\brief Default default-constructor.
-    constexpr eager_split_view()                         = default;
+    constexpr eager_split_view()                                     = default;
     //!\brief Default copy-constructor.
-    constexpr eager_split_view(eager_split_view const &) = default;
+    constexpr eager_split_view(eager_split_view const &)             = default;
     //!\brief Default move-constructor.
-    constexpr eager_split_view(eager_split_view &&)      = default;
+    constexpr eager_split_view(eager_split_view &&)                  = default;
     //!\brief Default copy-assignment.
     constexpr eager_split_view & operator=(eager_split_view const &) = default;
     //!\brief Default move-assignment
-    constexpr eager_split_view & operator=(eager_split_view &&) = default;
+    constexpr eager_split_view & operator=(eager_split_view &&)      = default;
     //!\brief Default destructor.
-    ~eager_split_view()                                         = default;
+    ~eager_split_view()                                              = default;
 
     //!\brief Construction from the underlying view.
     explicit constexpr eager_split_view(std::string_view urng_, char delimiter_, bool skip_quotes_ = false) :

--- a/include/bio/exception.hpp
+++ b/include/bio/exception.hpp
@@ -75,10 +75,17 @@ struct unexpected_end_of_input : std::runtime_error
 // ----------------------------------------------------------------------------
 
 //!\brief Thrown if information given to output format didn't match expectations.
-struct format_error : std::invalid_argument
+struct format_error : std::runtime_error
 {
     //!\brief Constructor that forwards the exception string.
-    format_error(std::string const & s) : std::invalid_argument{s} {}
+    format_error(std::string const & s) : std::runtime_error{s} {}
+};
+
+//!\brief Thrown if a writer requires a header but it isn't provided.
+struct missing_header_error : std::runtime_error
+{
+    //!\brief Constructor that forwards the exception string.
+    missing_header_error(std::string const & s) : std::runtime_error{s} {}
 };
 
 //!\}

--- a/include/bio/format/fasta_input_handler.hpp
+++ b/include/bio/format/fasta_input_handler.hpp
@@ -193,12 +193,12 @@ public:
     /*!\name Constructors, destructor and assignment.
      * \{
      */
-    format_input_handler()                             = default;            //!< Defaulted.
-    format_input_handler(format_input_handler const &) = delete;             //!< Deleted.
-    format_input_handler(format_input_handler &&)      = default;            //!< Defaulted.
-    ~format_input_handler()                            = default;            //!< Defaulted.
-    format_input_handler & operator=(format_input_handler const &) = delete; //!< Deleted.
-    format_input_handler & operator=(format_input_handler &&) = default;     //!< Defaulted.
+    format_input_handler()                                         = default; //!< Defaulted.
+    format_input_handler(format_input_handler const &)             = delete;  //!< Deleted.
+    format_input_handler(format_input_handler &&)                  = default; //!< Defaulted.
+    ~format_input_handler()                                        = default; //!< Defaulted.
+    format_input_handler & operator=(format_input_handler const &) = delete;  //!< Deleted.
+    format_input_handler & operator=(format_input_handler &&)      = default; //!< Defaulted.
 
     /*!\brief Construct with an options object.
      * \param[in,out] str The input stream.

--- a/include/bio/format/format_input_handler.hpp
+++ b/include/bio/format/format_input_handler.hpp
@@ -190,12 +190,12 @@ private:
      * \brief These are all private to prevent wrong instantiation.
      * \{
      */
-    format_input_handler_base()                                  = default;            //!< Defaulted.
-    format_input_handler_base(format_input_handler_base const &) = delete;             //!< Deleted.
-    format_input_handler_base(format_input_handler_base &&)      = default;            //!< Defaulted.
-    ~format_input_handler_base()                                 = default;            //!< Defaulted.
-    format_input_handler_base & operator=(format_input_handler_base const &) = delete; //!< Deleted.
-    format_input_handler_base & operator=(format_input_handler_base &&) = default;     //!< Defaulted.
+    format_input_handler_base()                                              = default; //!< Defaulted.
+    format_input_handler_base(format_input_handler_base const &)             = delete;  //!< Deleted.
+    format_input_handler_base(format_input_handler_base &&)                  = default; //!< Defaulted.
+    ~format_input_handler_base()                                             = default; //!< Defaulted.
+    format_input_handler_base & operator=(format_input_handler_base const &) = delete;  //!< Deleted.
+    format_input_handler_base & operator=(format_input_handler_base &&)      = default; //!< Defaulted.
 
     //!\brief Construct from a std::istream.
     format_input_handler_base(std::istream & str) : stream{&str}

--- a/include/bio/format/format_output_handler.hpp
+++ b/include/bio/format/format_output_handler.hpp
@@ -78,7 +78,7 @@ private:
     //!\brief Write chracter ranges.
     template <std::ranges::input_range rng_t>
         requires(std::convertible_to<std::ranges::range_reference_t<rng_t>, char>)
-    void write_field_aux(rng_t && range) { it->write_range(range); }
+    void write_field_aux(rng_t && range) { to_derived()->it->write_range(range); }
 
     //!\brief Write alphabet ranges.
     template <std::ranges::input_range rng_t>
@@ -92,11 +92,11 @@ private:
     void write_field_aux(std::span<std::byte const> const range)
     {
         std::string_view const v{range.data(), range.size()};
-        it->write_range(v);
+        to_derived()->it->write_range(v);
     }
 
     //!\brief Write numbers.
-    void write_field_aux(seqan3::arithmetic auto number) { it->write_number(number); }
+    void write_field_aux(seqan3::arithmetic auto number) { to_derived()->it->write_number(number); }
 
     //!\brief Write bool.
     void write_field_aux(bool)
@@ -140,12 +140,12 @@ private:
      * \brief These are all private to prevent wrong instantiation.
      * \{
      */
-    format_output_handler_base()                                   = default;            //!< Defaulted.
-    format_output_handler_base(format_output_handler_base const &) = delete;             //!< Deleted.
-    format_output_handler_base(format_output_handler_base &&)      = default;            //!< Defaulted.
-    ~format_output_handler_base()                                  = default;            //!< Defaulted.
-    format_output_handler_base & operator=(format_output_handler_base const &) = delete; //!< Deleted.
-    format_output_handler_base & operator=(format_output_handler_base &&) = default;     //!< Defaulted.
+    format_output_handler_base()                                               = delete;  //!< Deleted.
+    format_output_handler_base(format_output_handler_base const &)             = delete;  //!< Deleted.
+    format_output_handler_base(format_output_handler_base &&)                  = default; //!< Defaulted.
+    ~format_output_handler_base()                                              = default; //!< Defaulted.
+    format_output_handler_base & operator=(format_output_handler_base const &) = delete;  //!< Deleted.
+    format_output_handler_base & operator=(format_output_handler_base &&)      = default; //!< Defaulted.
 
     //!\brief Construct from a std::istream.
     format_output_handler_base(std::ostream & str) : stream{&str}, it{str} {}

--- a/include/bio/format/vcf_input_handler.hpp
+++ b/include/bio/format/vcf_input_handler.hpp
@@ -252,7 +252,7 @@ private:
         for (std::string_view subfield : raw_field | detail::eager_split(';'))
         {
             int32_t idx = -1;
-            if (auto it = header.string_to_filter_pos().find(raw_field);
+            if (auto it = header.string_to_filter_pos().find(subfield);
                 it == header.string_to_filter_pos().end()) // filter name was not in header, insert!
             {
                 header.filters.push_back(
@@ -297,7 +297,7 @@ private:
         {
             var_io::header::info_t info;
             info.id          = info_name;
-            info.description = "\"Automatically added by SeqAn3.\"";
+            info.description = "\"Automatically added by B.I.O..\"";
 
             if (info_value.empty()) // no "=" → flag
             {
@@ -428,7 +428,7 @@ private:
             format.id          = format_name;
             format.number      = 1;
             format.type        = var_io::dynamic_type_id::string;
-            format.description = "\"Automatically added by SeqAn3.\"";
+            format.description = "\"Automatically added by B.I.O..\"";
 
             // create a new header with new format and replace current one
             header.formats.push_back(std::move(format));
@@ -599,12 +599,12 @@ public:
     /*!\name Constructors, destructor and assignment.
      * \{
      */
-    format_input_handler()                             = default;            //!< Defaulted.
-    format_input_handler(format_input_handler const &) = delete;             //!< Deleted.
-    format_input_handler(format_input_handler &&)      = default;            //!< Defaulted.
-    ~format_input_handler()                            = default;            //!< Defaulted.
-    format_input_handler & operator=(format_input_handler const &) = delete; //!< Deleted.
-    format_input_handler & operator=(format_input_handler &&) = default;     //!< Defaulted.
+    format_input_handler()                                         = default; //!< Defaulted.
+    format_input_handler(format_input_handler const &)             = delete;  //!< Deleted.
+    format_input_handler(format_input_handler &&)                  = default; //!< Defaulted.
+    ~format_input_handler()                                        = default; //!< Defaulted.
+    format_input_handler & operator=(format_input_handler const &) = delete;  //!< Deleted.
+    format_input_handler & operator=(format_input_handler &&)      = default; //!< Defaulted.
 
     /*!\brief Construct with an options object.
      * \param[in,out] str The input stream.

--- a/include/bio/format/vcf_output_handler.hpp
+++ b/include/bio/format/vcf_output_handler.hpp
@@ -191,7 +191,7 @@ private:
     {
         if constexpr (detail::is_dynamic_type<std::remove_cvref_t<decltype(var)>>)
         {
-            if (!detail::type_id_is_compatible(type_id, var_io::dynamic_type_id{static_cast<int32_t>(var.index())}))
+            if (!detail::type_id_is_compatible(type_id, var_io::dynamic_type_id{var.index()}))
                 throw format_error{"The variant was not in the proper state."}; // TODO improve text
         }
         else

--- a/include/bio/plain_io/misc.hpp
+++ b/include/bio/plain_io/misc.hpp
@@ -99,11 +99,11 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    constexpr header_kind() noexcept                    = default;             //!< Defaulted.
-    constexpr header_kind(header_kind const &) noexcept = default;             //!< Defaulted.
-    constexpr header_kind(header_kind &&) noexcept      = default;             //!< Defaulted.
+    constexpr header_kind() noexcept                                = default; //!< Defaulted.
+    constexpr header_kind(header_kind const &) noexcept             = default; //!< Defaulted.
+    constexpr header_kind(header_kind &&) noexcept                  = default; //!< Defaulted.
     constexpr header_kind & operator=(header_kind const &) noexcept = default; //!< Defaulted.
-    constexpr header_kind & operator=(header_kind &&) noexcept = default;      //!< Defaulted.
+    constexpr header_kind & operator=(header_kind &&) noexcept      = default; //!< Defaulted.
 
     //!\brief Initialise to the "none"-state.
     constexpr header_kind(decltype(none)) noexcept : state{none_state} {}

--- a/include/bio/plain_io/reader.hpp
+++ b/include/bio/plain_io/reader.hpp
@@ -86,12 +86,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    plaintext_input_iterator() noexcept                                 = default;             //!< Defaulted.
-    plaintext_input_iterator(plaintext_input_iterator const &) noexcept = default;             //!< Defaulted.
-    plaintext_input_iterator(plaintext_input_iterator &&) noexcept      = default;             //!< Defaulted.
+    plaintext_input_iterator() noexcept                                             = default; //!< Defaulted.
+    plaintext_input_iterator(plaintext_input_iterator const &) noexcept             = default; //!< Defaulted.
+    plaintext_input_iterator(plaintext_input_iterator &&) noexcept                  = default; //!< Defaulted.
     plaintext_input_iterator & operator=(plaintext_input_iterator const &) noexcept = default; //!< Defaulted.
-    plaintext_input_iterator & operator=(plaintext_input_iterator &&) noexcept = default;      //!< Defaulted.
-    ~plaintext_input_iterator() noexcept                                       = default;      //!< Defaulted.
+    plaintext_input_iterator & operator=(plaintext_input_iterator &&) noexcept      = default; //!< Defaulted.
+    ~plaintext_input_iterator() noexcept                                            = default; //!< Defaulted.
 
     //!\brief Construct from a stream buffer.
     explicit plaintext_input_iterator(std::basic_streambuf<char> & ibuf, bool const read_first_record = true) :
@@ -384,17 +384,17 @@ public:
      * \{
      */
     //!\brief Default constructor is explicitly deleted, you need to give a stream or file name.
-    reader()               = delete;
+    reader()                           = delete;
     //!\brief Copy construction is explicitly deleted, because you can't have multiple access to the same file.
-    reader(reader const &) = delete;
+    reader(reader const &)             = delete;
     //!\brief Move construction is defaulted.
-    reader(reader &&)      = default;
+    reader(reader &&)                  = default;
     //!\brief Destructor is defaulted.
-    ~reader()              = default;
+    ~reader()                          = default;
     //!\brief Copy assignment is explicitly deleted, because you can't have multiple access to the same file.
     reader & operator=(reader const &) = delete;
     //!\brief Move assignment is defaulted.
-    reader & operator=(reader &&) = default;
+    reader & operator=(reader &&)      = default;
 
     /*!\brief Construct from filename.
      * \param[in] filename        Path to the file you wish to open.

--- a/include/bio/plain_io/writer.hpp
+++ b/include/bio/plain_io/writer.hpp
@@ -112,12 +112,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    plaintext_output_iterator() noexcept                                  = default;             //!< Defaulted.
-    plaintext_output_iterator(plaintext_output_iterator const &) noexcept = default;             //!< Defaulted.
-    plaintext_output_iterator(plaintext_output_iterator &&) noexcept      = default;             //!< Defaulted.
-    ~plaintext_output_iterator() noexcept                                 = default;             //!< Defaulted.
+    plaintext_output_iterator() noexcept                                              = default; //!< Defaulted.
+    plaintext_output_iterator(plaintext_output_iterator const &) noexcept             = default; //!< Defaulted.
+    plaintext_output_iterator(plaintext_output_iterator &&) noexcept                  = default; //!< Defaulted.
+    ~plaintext_output_iterator() noexcept                                             = default; //!< Defaulted.
     plaintext_output_iterator & operator=(plaintext_output_iterator const &) noexcept = default; //!< Defaulted.
-    plaintext_output_iterator & operator=(plaintext_output_iterator &&) noexcept = default;      //!< Defaulted.
+    plaintext_output_iterator & operator=(plaintext_output_iterator &&) noexcept      = default; //!< Defaulted.
 
     //!\brief Construct from a stream.
     explicit plaintext_output_iterator(std::ostream & ostr) : stream_it{ostr} {}
@@ -316,17 +316,17 @@ public:
      * \{
      */
     //!\brief Default constructor is explicitly deleted, you need to give a stream or file name.
-    writer()               = delete;
+    writer()                           = delete;
     //!\brief Copy construction is explicitly deleted, because you can't have multiple access to the same file.
-    writer(writer const &) = delete;
+    writer(writer const &)             = delete;
     //!\brief Move construction is defaulted.
-    writer(writer &&)      = default;
+    writer(writer &&)                  = default;
     //!\brief Copy assignment is explicitly deleted, because you can't have multiple access to the same file.
     writer & operator=(writer const &) = delete;
     //!\brief Move assignment is defaulted.
-    writer & operator=(writer &&) = default;
+    writer & operator=(writer &&)      = default;
     //!\brief Destructor is defaulted.
-    ~writer()                     = default;
+    ~writer()                          = default;
 
     /*!\brief Construct from filename.
      * \param[in] filename        Path that you wish to write to.

--- a/include/bio/record.hpp
+++ b/include/bio/record.hpp
@@ -15,12 +15,11 @@
 
 #include <tuple>
 
-#include <bio/platform.hpp>
-
 #include <seqan3/core/detail/template_inspection.hpp>
 #include <seqan3/utility/type_list/traits.hpp>
 #include <seqan3/utility/type_list/type_list.hpp>
 
+#include <bio/detail/concept.hpp>
 #include <bio/misc.hpp>
 
 namespace bio
@@ -140,7 +139,7 @@ private:
     //!\brief Auxiliary functions for clear().
     template <typename t>
         //!\cond REQ
-        requires requires(t & v) { v.clear(); }
+        requires(requires(t & v) { v.clear(); })
     //!\endcond
     static constexpr void clear_element(t & v) noexcept(noexcept(v.clear())) { v.clear(); }
 
@@ -164,12 +163,12 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    record()               = default;             //!< Defaulted.
-    record(record const &) = default;             //!< Defaulted.
-    record(record &&)      = default;             //!< Defaulted.
-    ~record()              = default;             //!< Defaulted.
+    record()                           = default; //!< Defaulted.
+    record(record const &)             = default; //!< Defaulted.
+    record(record &&)                  = default; //!< Defaulted.
+    ~record()                          = default; //!< Defaulted.
     record & operator=(record const &) = default; //!< Defaulted.
-    record & operator=(record &&) = default;      //!< Defaulted.
+    record & operator=(record &&)      = default; //!< Defaulted.
 
     //!\brief Inherit tuple's constructors.
     using base_type::base_type;
@@ -222,9 +221,15 @@ public:
 //!\brief A macro that defines all getter functions for fields contained in bio::record.
 #define BIO_RECORD_MEMBER(F)                                                                                           \
     /*!\brief Return the bio::field F if available.*/                                                                  \
-    decltype(auto) F() noexcept(noexcept(get<field::F>())) { return get<field::F>(); }                                 \
+    decltype(auto) F() noexcept(noexcept(get<field::F>()))                                                             \
+    {                                                                                                                  \
+        return get<field::F>();                                                                                        \
+    }                                                                                                                  \
     /*!\brief Return the bio::field F if available. [const-qualified version] */                                       \
-    decltype(auto) F() const noexcept(noexcept(get<field::F>())) { return get<field::F>(); }
+    decltype(auto) F() const noexcept(noexcept(get<field::F>()))                                                       \
+    {                                                                                                                  \
+        return get<field::F>();                                                                                        \
+    }
 
     /*!\name Member accessors
      * \brief This is the same as calling #get<field::X>(); functions are only defined if record has that element.
@@ -314,7 +319,7 @@ struct record_element<f, record<field_ids, field_types>> :
 
 //!\brief Like std::tuple_element but with bio::field on bio::record. [type trait shortcut]
 template <field f, typename t>
-    requires requires { typename record_element<f, t>::type; }
+    requires(requires { typename record_element<f, t>::type; })
 using record_element_t = typename record_element<f, t>::type;
 
 //-------------------------------------------------------------------------------

--- a/include/bio/stream/compression.hpp
+++ b/include/bio/stream/compression.hpp
@@ -58,7 +58,19 @@ struct compression_traits
      * Note that this static member is not `const` and may be modified to allow
      * user-provided extensions.
      */
-    static inline std::vector<std::string> file_extensions = {"gz", "bgz", "bgzf"};
+    static inline std::vector<std::string> file_extensions;
+
+    /*!\brief Valid file extensions that are not added to an existing extension but (usually) still imply compression.
+     *
+     * \details
+     *
+     * Note that this static member is not `const` and may be modified to allow
+     * user-provided extensions.
+     *
+     * These file extensions are not "additional" (e.g. the ".gz" in ".tar.gz")
+     * but still indicate the usage of a specific compression (e.g. ".tgz").
+     */
+    static inline std::vector<std::string> implied_file_extensions;
 
     //!\brief The magic byte sequence to disambiguate the compression format.
     static constexpr std::string_view magic_header = "";
@@ -79,6 +91,9 @@ struct compression_traits<compression_format::bgzf> : compression_traits<compres
 
     //!\copydoc bio::compression_traits<compression_format::none>::file_extensions
     static inline std::vector<std::string> file_extensions = {"gz", "bgz", "bgzf"};
+
+    //!\copydoc bio::compression_traits<compression_format::none>::implied_file_extensions
+    static inline std::vector<std::string> implied_file_extensions = {"bcf", "bam"};
 
     //!\copydoc bio::compression_traits<compression_format::none>::magic_header
     static constexpr std::string_view magic_header{// GZip header
@@ -155,7 +170,7 @@ struct compression_traits<compression_format::zstd> : compression_traits<compres
     //!\copydoc bio::compression_traits<compression_format::none>::magic_header
     static constexpr std::string_view magic_header{"\x28\xb5\x2f\xfd", 4};
 
-    // NOT YET SUPPORTED BY SEQAN
+    // NOT YET SUPPORTED BY BIO
 };
 
 } // namespace bio
@@ -291,7 +306,7 @@ inline compression_format detect_format_from_magic_header(std::string_view const
 }
 
 //-------------------------------------------------------------------------------
-// detect_format_from_filename
+// detect_format_from_extension
 //-------------------------------------------------------------------------------
 
 /*!\brief Deduce bio::compression_format from a filename extension.
@@ -301,7 +316,7 @@ inline compression_format detect_format_from_magic_header(std::string_view const
  * Note that this function checks BGZF before GZ which means that it always selects BGZF for the extension ".gz".
  * This is desired, because many biological formats expect this.
  */
-inline compression_format detect_format_from_filename(std::filesystem::path const & path)
+inline compression_format detect_format_from_extension(std::filesystem::path const & path)
 {
     auto ext = path.extension().string();
 
@@ -323,6 +338,41 @@ inline compression_format detect_format_from_filename(std::filesystem::path cons
         if (ext == ext2)
             return compression_format::zstd;
     for (std::string_view const ext2 : compression_traits<compression_format::bgzf>::file_extensions)
+        if (ext == ext2)
+            return compression_format::bgzf;
+
+    return compression_format::none;
+}
+
+/*!\brief Deduce bio::compression_format from a filename extension.
+ * \ingroup stream
+ * \details
+ *
+ * Note that this function checks BGZF before GZ which means that it always selects BGZF for the extension ".gz".
+ * This is desired, because many biological formats expect this.
+ */
+inline compression_format detect_format_from_implied_extension(std::filesystem::path const & path)
+{
+    auto ext = path.extension().string();
+
+    if (!ext.starts_with('.'))
+        return compression_format::none;
+    else
+        ext = ext.substr(1);
+
+    for (std::string_view const ext2 : compression_traits<compression_format::bgzf>::implied_file_extensions)
+        if (ext == ext2)
+            return compression_format::bgzf;
+    for (std::string_view const ext2 : compression_traits<compression_format::gz>::implied_file_extensions)
+        if (ext == ext2)
+            return compression_format::gz;
+    for (std::string_view const ext2 : compression_traits<compression_format::bz2>::implied_file_extensions)
+        if (ext == ext2)
+            return compression_format::bz2;
+    for (std::string_view const ext2 : compression_traits<compression_format::zstd>::implied_file_extensions)
+        if (ext == ext2)
+            return compression_format::zstd;
+    for (std::string_view const ext2 : compression_traits<compression_format::bgzf>::implied_file_extensions)
         if (ext == ext2)
             return compression_format::bgzf;
 

--- a/include/bio/stream/detail/bgzf_istream.hpp
+++ b/include/bio/stream/detail/bgzf_istream.hpp
@@ -503,7 +503,10 @@ public:
     }
 
     // returns the compressed input istream
-    istream_reference get_istream() { return serializer.istream; };
+    istream_reference get_istream()
+    {
+        return serializer.istream;
+    };
 };
 
 // --------------------------------------------------------------------------

--- a/include/bio/stream/transparent_istream.hpp
+++ b/include/bio/stream/transparent_istream.hpp
@@ -204,10 +204,10 @@ public:
     /*!\name Constructors, destructor and assignment
      * \{
      */
-    transparent_istream() : std::basic_istream<char>{} {}                  //!< Call default constructor of base.
-    transparent_istream(transparent_istream const &) = delete;             //!< Deleted.
-    transparent_istream & operator=(transparent_istream &&) = default;     //!< Defaulted.
-    transparent_istream & operator=(transparent_istream const &) = delete; //!< Defaulted.
+    transparent_istream() : std::basic_istream<char>{} {}                   //!< Call default constructor of base.
+    transparent_istream(transparent_istream const &)             = delete;  //!< Deleted.
+    transparent_istream & operator=(transparent_istream &&)      = default; //!< Defaulted.
+    transparent_istream & operator=(transparent_istream const &) = delete;  //!< Defaulted.
 
     //!\brief Move construction swaps the members maually before setting the buffer s.t. it is not invalidated.
     transparent_istream(transparent_istream && rhs)

--- a/test/snippet/var_io/var_io_writer.cpp
+++ b/test/snippet/var_io/var_io_writer.cpp
@@ -85,9 +85,16 @@ writer.emplace_back(bio::vtag<bio::field::chrom, bio::field::pos, bio::field::re
 
 {
 //![options]
-bio::var_io::writer writer{"example.vcf",
+bio::var_io::writer writer{"example2.vcf",
                            bio::var_io::writer_options{ .windows_eol = true }};
 //![options]
+
+// add header so destructor works
+std::string_view const text_header =
+R"(##fileformat=VCFv4.3
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+)";
+writer.set_header(bio::var_io::header{text_header});
 }
 
 {
@@ -101,6 +108,7 @@ bio::var_io::writer writer{"example.vcf",
 bio::var_io::reader{"example.bcf"} | bio::var_io::writer{"example.vcf"};
 //![inout]
 }
+
 {
 //![inout2]
 auto pass = [] (auto & rec)
@@ -113,6 +121,7 @@ r | std::views::filter(pass) | bio::var_io::writer{"example.vcf"};
 //![inout2]
 //TODO collapse the above once https://gcc.gnu.org/bugzilla/show_bug.cgi?id=103904 is resolved
 }
+
 {
 //![inout3]
 bio::var_io::reader reader{"example.bcf"};
@@ -128,4 +137,6 @@ for (auto & rec : reader)
 //================= POST ==========================
     std::filesystem::remove("example.bcf");
     std::filesystem::remove("example.vcf");
+    std::filesystem::remove("example2.vcf");
+    std::filesystem::remove("example5.vcf");
 }

--- a/test/unit/format/bcf_input_test.cpp
+++ b/test/unit/format/bcf_input_test.cpp
@@ -122,30 +122,30 @@ void field_types()
                                                            decltype(bio::var_io::field_types_bcf_style<own>)>>;
     using record_t = bio::record<decltype(bio::var_io::default_field_ids), fields_t>;
 
+    using int_t       = int8_t;
+    constexpr auto mv = bio::var_io::missing_value<int_t>;
+
     std::vector<record_t> recs;
 
     if constexpr (s == style::def)
-        recs = example_records_default_style<own, int8_t>();
+        recs = example_records_default_style<own, int_t>();
     else if constexpr (s == style::vcf)
-        recs = example_records_vcf_style<own, int8_t>();
+        recs = example_records_vcf_style<own, int_t>();
     else
-        recs = example_records_bcf_style<own, int8_t>();
+        recs = example_records_bcf_style<own, int_t>();
 
     // this workaround is pending clarification in https://github.com/samtools/hts-specs/issues/593
     if constexpr (s == style::vcf)
     {
-        bio::detail::get_second(recs[1].genotypes()).back().push_back(std::vector<int8_t>{-128});
-        bio::detail::get_second(recs[2].genotypes()).back().push_back(std::vector<int8_t>{-128});
-        bio::detail::get_second(recs[3].genotypes()).back().push_back(std::vector<int8_t>{-128});
+        bio::detail::get_second(recs[1].genotypes()).back().push_back(std::vector<int_t>{mv});
+        bio::detail::get_second(recs[2].genotypes()).back().push_back(std::vector<int_t>{mv});
+        bio::detail::get_second(recs[3].genotypes()).back().push_back(std::vector<int_t>{mv});
     }
     else
     {
-        std::get<std::vector<std::vector<int8_t>>>(bio::detail::get_second(recs[1].genotypes().back()))
-          .push_back({-128});
-        std::get<std::vector<std::vector<int8_t>>>(bio::detail::get_second(recs[2].genotypes().back()))
-          .push_back({-128});
-        std::get<std::vector<std::vector<int8_t>>>(bio::detail::get_second(recs[3].genotypes().back()))
-          .push_back({-128});
+        std::get<std::vector<std::vector<int_t>>>(bio::detail::get_second(recs[1].genotypes().back())).push_back({mv});
+        std::get<std::vector<std::vector<int_t>>>(bio::detail::get_second(recs[2].genotypes().back())).push_back({mv});
+        std::get<std::vector<std::vector<int_t>>>(bio::detail::get_second(recs[3].genotypes().back())).push_back({mv});
     }
 
     for (auto & rec : recs)

--- a/test/unit/format/vcf_data.hpp
+++ b/test/unit/format/vcf_data.hpp
@@ -250,7 +250,7 @@ auto example_records_default_style()
 
     bio::var_io::record_private_data priv{};
     constexpr int_t mv = bio::var_io::missing_value<int_t>;
-    using ivec          = std::vector<int32_t>;  // not int_t because dynamic_vector_type doesn have vector<int8_t>
+    using ivec          = std::vector<int_t>;
     using ivecvec       = std::vector<std::vector<int_t>>;
     using fvec          = std::vector<float>;
     using svec          = std::conditional_t<own == bio::ownership::shallow,
@@ -259,11 +259,11 @@ auto example_records_default_style()
 
     // clang-format off
     std::vector<record_t> recs{
-    {"20", 14370,   "rs6054257", make_ref<own>("G"),   {"A"},        29, {"PASS"}, {{"NS",3}, {"DP", 14}, {"AF", fvec{0.5f}}, {"DB", true}, {"H2", true}        }, { {"GT", svec{"0|0", "1|0", "1/1"}}, {"GQ", ivec{48, 48, 43}}, {"DP", ivec{1, 8, 5}}, {"HQ", ivecvec{{51,51}, {51,51}, {mv,mv} }}}, priv},
-    {"20", 17330,   ".",         make_ref<own>("T"),   {"A"},        3,  {"q10"},  {{"NS",3}, {"DP", 11}, {"AF", fvec{0.017f}}                                  }, { {"GT", svec{"0|0", "0|1", "0/0"}}, {"GQ", ivec{49,  3, 41}}, {"DP", ivec{3, 5, 3}}, {"HQ", ivecvec{{58,50}, {65, 3}          }}}, priv},
-    {"20", 1110696, "rs6040355", make_ref<own>("A"),   {"G","T"},    67, {"PASS"}, {{"NS",2}, {"DP", 10}, {"AF", fvec{0.333f,0.667f}}, {"AA", "T"}, {"DB", true}}, { {"GT", svec{"1|2", "2|1", "2/2"}}, {"GQ", ivec{21,  2, 35}}, {"DP", ivec{6, 0, 4}}, {"HQ", ivecvec{{23,27}, {18, 2}          }}}, priv},
-    {"20", 1230237, ".",         make_ref<own>("T"),   {},           47, {"PASS"}, {{"NS",3}, {"DP", 13}, {"AA", "T"}                                           }, { {"GT", svec{"0|0", "0|0", "0/0"}}, {"GQ", ivec{54, 48, 61}}, {"DP", ivec{7, 4, 2}}, {"HQ", ivecvec{{56,60}, {51,51}          }}}, priv},
-    {"20", 1234567, "microsat1", make_ref<own>("GTC"), {"G","GTCT"}, 50, {"PASS"}, {{"NS",3}, {"DP", 9 }, {"AA", "G"}                                           }, { {"GT", svec{"0/1", "0/2", "1/1"}}, {"GQ", ivec{35, 17, 40}}, {"DP", ivec{4, 2, 3}}                                             }, priv},
+    {"20", 14370,   "rs6054257", make_ref<own>("G"),   {"A"},        29, {"PASS"}, {{"NS",(int_t)3}, {"DP", (int_t)14}, {"AF", fvec{0.5f}}, {"DB", true}, {"H2", true}        }, { {"GT", svec{"0|0", "1|0", "1/1"}}, {"GQ", ivec{48, 48, 43}}, {"DP", ivec{1, 8, 5}}, {"HQ", ivecvec{{51,51}, {51,51}, {mv,mv} }}}, priv},
+    {"20", 17330,   ".",         make_ref<own>("T"),   {"A"},        3,  {"q10"},  {{"NS",(int_t)3}, {"DP", (int_t)11}, {"AF", fvec{0.017f}}                                  }, { {"GT", svec{"0|0", "0|1", "0/0"}}, {"GQ", ivec{49,  3, 41}}, {"DP", ivec{3, 5, 3}}, {"HQ", ivecvec{{58,50}, {65, 3}          }}}, priv},
+    {"20", 1110696, "rs6040355", make_ref<own>("A"),   {"G","T"},    67, {"PASS"}, {{"NS",(int_t)2}, {"DP", (int_t)10}, {"AF", fvec{0.333f,0.667f}}, {"AA", "T"}, {"DB", true}}, { {"GT", svec{"1|2", "2|1", "2/2"}}, {"GQ", ivec{21,  2, 35}}, {"DP", ivec{6, 0, 4}}, {"HQ", ivecvec{{23,27}, {18, 2}          }}}, priv},
+    {"20", 1230237, ".",         make_ref<own>("T"),   {},           47, {"PASS"}, {{"NS",(int_t)3}, {"DP", (int_t)13}, {"AA", "T"}                                           }, { {"GT", svec{"0|0", "0|0", "0/0"}}, {"GQ", ivec{54, 48, 61}}, {"DP", ivec{7, 4, 2}}, {"HQ", ivecvec{{56,60}, {51,51}          }}}, priv},
+    {"20", 1234567, "microsat1", make_ref<own>("GTC"), {"G","GTCT"}, 50, {"PASS"}, {{"NS",(int_t)3}, {"DP", (int_t)9 }, {"AA", "G"}                                           }, { {"GT", svec{"0/1", "0/2", "1/1"}}, {"GQ", ivec{35, 17, 40}}, {"DP", ivec{4, 2, 3}}                                             }, priv},
     };
     // clang-format on
 
@@ -284,11 +284,11 @@ auto example_records_vcf_style()
 
     // clang-format off
     std::vector<record_t> recs{
-    {"20", 14370,   "rs6054257", make_ref<own>("G"),   {"A"},        29, {"PASS"}, {{"NS",3}, {"DP", 14}, {"AF", fvec{0.5f}}, {"DB", true}, {"H2", true}        }, { {"GT", "GQ", "DP", "HQ"}, {{"0|0", 48,1,ivec{51,51}}, {"1|0",48,8,ivec{51,51}}, {"1/1",43,5,ivec{mv,mv}}}}, priv},
-    {"20", 17330,   ".",         make_ref<own>("T"),   {"A"},        3,  {"q10"},  {{"NS",3}, {"DP", 11}, {"AF", fvec{0.017f}}                                  }, { {"GT", "GQ", "DP", "HQ"}, {{"0|0", 49,3,ivec{58,50}}, {"0|1", 3,5,ivec{65, 3}}, {"0/0",41,3            }}}, priv},
-    {"20", 1110696, "rs6040355", make_ref<own>("A"),   {"G","T"},    67, {"PASS"}, {{"NS",2}, {"DP", 10}, {"AF", fvec{0.333f,0.667f}}, {"AA", "T"}, {"DB", true}}, { {"GT", "GQ", "DP", "HQ"}, {{"1|2", 21,6,ivec{23,27}}, {"2|1", 2,0,ivec{18, 2}}, {"2/2",35,4            }}}, priv},
-    {"20", 1230237, ".",         make_ref<own>("T"),   {},           47, {"PASS"}, {{"NS",3}, {"DP", 13}, {"AA", "T"}                                           }, { {"GT", "GQ", "DP", "HQ"}, {{"0|0", 54,7,ivec{56,60}}, {"0|0",48,4,ivec{51,51}}, {"0/0",61,2            }}}, priv},
-    {"20", 1234567, "microsat1", make_ref<own>("GTC"), {"G","GTCT"}, 50, {"PASS"}, {{"NS",3}, {"DP", 9 }, {"AA", "G"}                                           }, { {"GT", "GQ", "DP"      }, {{"0/1", 35,4            }, {"0/2",17,2            }, {"1/1",40,3            }}}, priv}
+    {"20", 14370,   "rs6054257", make_ref<own>("G"),   {"A"},        29, {"PASS"}, {{"NS",(int_t)3}, {"DP", (int_t)14}, {"AF", fvec{0.5f}}, {"DB", true}, {"H2", true}        }, { {"GT", "GQ", "DP", "HQ"}, {{"0|0", (int_t)48,(int_t)1,ivec{51,51}}, {"1|0",(int_t)48,(int_t)8,ivec{51,51}}, {"1/1",(int_t)43,(int_t)5,ivec{mv,mv}}}}, priv},
+    {"20", 17330,   ".",         make_ref<own>("T"),   {"A"},        3,  {"q10"},  {{"NS",(int_t)3}, {"DP", (int_t)11}, {"AF", fvec{0.017f}}                                  }, { {"GT", "GQ", "DP", "HQ"}, {{"0|0", (int_t)49,(int_t)3,ivec{58,50}}, {"0|1",(int_t) 3,(int_t)5,ivec{65, 3}}, {"0/0",(int_t)41,(int_t)3            }}}, priv},
+    {"20", 1110696, "rs6040355", make_ref<own>("A"),   {"G","T"},    67, {"PASS"}, {{"NS",(int_t)2}, {"DP", (int_t)10}, {"AF", fvec{0.333f,0.667f}}, {"AA", "T"}, {"DB", true}}, { {"GT", "GQ", "DP", "HQ"}, {{"1|2", (int_t)21,(int_t)6,ivec{23,27}}, {"2|1",(int_t) 2,(int_t)0,ivec{18, 2}}, {"2/2",(int_t)35,(int_t)4            }}}, priv},
+    {"20", 1230237, ".",         make_ref<own>("T"),   {},           47, {"PASS"}, {{"NS",(int_t)3}, {"DP", (int_t)13}, {"AA", "T"}                                           }, { {"GT", "GQ", "DP", "HQ"}, {{"0|0", (int_t)54,(int_t)7,ivec{56,60}}, {"0|0",(int_t)48,(int_t)4,ivec{51,51}}, {"0/0",(int_t)61,(int_t)2            }}}, priv},
+    {"20", 1234567, "microsat1", make_ref<own>("GTC"), {"G","GTCT"}, 50, {"PASS"}, {{"NS",(int_t)3}, {"DP", (int_t)9 }, {"AA", "G"}                                           }, { {"GT", "GQ", "DP"      }, {{"0/1", (int_t)35,(int_t)4            }, {"0/2",(int_t)17,(int_t)2            }, {"1/1",(int_t)40,(int_t)3            }}}, priv}
     };
     // clang-format on
 
@@ -303,7 +303,7 @@ auto example_records_bcf_style()
 
     bio::var_io::record_private_data priv{};
     constexpr int_t mv  = bio::var_io::missing_value<int_t>;
-    using ivec          = std::vector<int32_t>;  // not int_t because dynamic_vector_type doesn have vector<int8_t>
+    using ivec          = std::vector<int_t>;
     using ivecvec       = std::vector<std::vector<int_t>>;
     using fvec          = std::vector<float>;
     using svec          = std::conditional_t<own == bio::ownership::shallow,
@@ -312,11 +312,11 @@ auto example_records_bcf_style()
 
     // clang-format off
     std::vector<record_t> recs{
-    {0, 14370,   "rs6054257", make_ref<own>("G"),   {"A"},        29, {0}, {{1,3}, {2, 14}, {3, fvec{0.5f}}, {5, true}, {6, true}        }, { {9, svec{"0|0", "1|0", "1/1"}}, {10, ivec{48, 48, 43}}, {2, ivec{1, 8, 5}}, {11, ivecvec{{51,51}, {51,51}, {mv,mv} }}}, priv},
-    {0, 17330,   ".",         make_ref<own>("T"),   {"A"},        3,  {7}, {{1,3}, {2, 11}, {3, fvec{0.017f}}                            }, { {9, svec{"0|0", "0|1", "0/0"}}, {10, ivec{49,  3, 41}}, {2, ivec{3, 5, 3}}, {11, ivecvec{{58,50}, {65, 3}          }}}, priv},
-    {0, 1110696, "rs6040355", make_ref<own>("A"),   {"G","T"},    67, {0}, {{1,2}, {2, 10}, {3, fvec{0.333f,0.667f}}, {4, "T"}, {5, true}}, { {9, svec{"1|2", "2|1", "2/2"}}, {10, ivec{21,  2, 35}}, {2, ivec{6, 0, 4}}, {11, ivecvec{{23,27}, {18, 2}          }}}, priv},
-    {0, 1230237, ".",         make_ref<own>("T"),   {},           47, {0}, {{1,3}, {2, 13}, {4, "T"}                                     }, { {9, svec{"0|0", "0|0", "0/0"}}, {10, ivec{54, 48, 61}}, {2, ivec{7, 4, 2}}, {11, ivecvec{{56,60}, {51,51}          }}}, priv},
-    {0, 1234567, "microsat1", make_ref<own>("GTC"), {"G","GTCT"}, 50, {0}, {{1,3}, {2, 9 }, {4, "G"}                                     }, { {9, svec{"0/1", "0/2", "1/1"}}, {10, ivec{35, 17, 40}}, {2, ivec{4, 2, 3}}                                           }, priv},
+    {0, 14370,   "rs6054257", make_ref<own>("G"),   {"A"},        29, {0}, {{1,(int_t)3}, {2, (int_t)14}, {3, fvec{0.5f}}, {5, true}, {6, true}        }, { {9, svec{"0|0", "1|0", "1/1"}}, {10, ivec{48, 48, 43}}, {2, ivec{1, 8, 5}}, {11, ivecvec{{51,51}, {51,51}, {mv,mv} }}}, priv},
+    {0, 17330,   ".",         make_ref<own>("T"),   {"A"},        3,  {7}, {{1,(int_t)3}, {2, (int_t)11}, {3, fvec{0.017f}}                            }, { {9, svec{"0|0", "0|1", "0/0"}}, {10, ivec{49,  3, 41}}, {2, ivec{3, 5, 3}}, {11, ivecvec{{58,50}, {65, 3}          }}}, priv},
+    {0, 1110696, "rs6040355", make_ref<own>("A"),   {"G","T"},    67, {0}, {{1,(int_t)2}, {2, (int_t)10}, {3, fvec{0.333f,0.667f}}, {4, "T"}, {5, true}}, { {9, svec{"1|2", "2|1", "2/2"}}, {10, ivec{21,  2, 35}}, {2, ivec{6, 0, 4}}, {11, ivecvec{{23,27}, {18, 2}          }}}, priv},
+    {0, 1230237, ".",         make_ref<own>("T"),   {},           47, {0}, {{1,(int_t)3}, {2, (int_t)13}, {4, "T"}                                     }, { {9, svec{"0|0", "0|0", "0/0"}}, {10, ivec{54, 48, 61}}, {2, ivec{7, 4, 2}}, {11, ivecvec{{56,60}, {51,51}          }}}, priv},
+    {0, 1234567, "microsat1", make_ref<own>("GTC"), {"G","GTCT"}, 50, {0}, {{1,(int_t)3}, {2, (int_t)9 }, {4, "G"}                                     }, { {9, svec{"0/1", "0/2", "1/1"}}, {10, ivec{35, 17, 40}}, {2, ivec{4, 2, 3}}                                           }, priv},
     };
     // clang-format on
 


### PR DESCRIPTION
Important things to note:
  * output handlers and writers are no longer required to be default-constructible
  * output handlers may write headers in their destructors and may throw if no header was set
  * compressions now have two sets of extensions (specific to format `.gz` but also "implied" ones like `.bam` or `.bcf`)
  * the output iterator now has some utilities for writing types in their byte-representation (useful for binary formats)

Clang-format has moved some things around again, but the stable release of version 14 is in two weeks, so we should be fine with this soon (clang-format will be fixed at version 14 for now!).

@smehringer Can you have a look at all commits except "var_io/vcf/bcf" (because that is likely long and not so relevant for you)?