### PR TITLE
[FIX] Replace include `<seqan3/std/filesystem>` with  `<filesystem>`

### DIFF
--- a/include/bio/var_io/writer.hpp
+++ b/include/bio/var_io/writer.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <iosfwd>
 
 #include <bio/detail/writer_base.hpp>
@@ -20,7 +21,6 @@
 #include <bio/format/vcf_output_handler.hpp>
 #include <bio/var_io/header.hpp>
 #include <bio/var_io/writer_options.hpp>
-#include <seqan3/std/filesystem>
 
 namespace bio::var_io
 {


### PR DESCRIPTION
Replace `#include <seqan3/std/filesystem>` with  `#include <filesystem>`.
With the update of the seqan3 submodule <seqan3/std/filesystem> is not needed anymore.