### PR TITLE
[FIX] type_descriptor_is_int & value_type_id_2_type_descriptor must be inline

### DIFF
--- a/include/bio/var_io/misc.hpp
+++ b/include/bio/var_io/misc.hpp
@@ -640,7 +640,7 @@ detail::bcf_type_descriptor smallest_int_desc(rng_t & range)
 }
 
 //!\brief Whether the value is any integer value.
-bool type_descriptor_is_int(bcf_type_descriptor const type_desc)
+inline bool type_descriptor_is_int(bcf_type_descriptor const type_desc)
 {
     switch (type_desc)
     {
@@ -654,7 +654,7 @@ bool type_descriptor_is_int(bcf_type_descriptor const type_desc)
 }
 
 //!\brief Convert from bio::var_io::value_type_id to bio::detail::bcf_type_descriptor.
-bcf_type_descriptor value_type_id_2_type_descriptor(var_io::value_type_id const type_id)
+inline bcf_type_descriptor value_type_id_2_type_descriptor(var_io::value_type_id const type_id)
 {
     switch (type_id)
     {


### PR DESCRIPTION
In order to fix linkage problems 
```bash
[100%] Linking CXX executable ../bin/iGenVar
duplicate symbol '__ZN3bio6detail22type_descriptor_is_intENS0_19bcf_type_descriptorE' in:
    CMakeFiles/iGenVar.dir/iGenVar.cpp.o
    ../lib/libiGenVar_lib.a(variant_output.cpp.o)
duplicate symbol '__ZN3bio6detail31value_type_id_2_type_descriptorENS_6var_io13value_type_idE' in:
    CMakeFiles/iGenVar.dir/iGenVar.cpp.o
    ../lib/libiGenVar_lib.a(variant_output.cpp.o)
ld: 2 duplicate symbols for architecture x86_64
collect2: error: ld returned 1 exit status
make[2]: *** [bin/iGenVar] Error 1
make[1]: *** [src/CMakeFiles/iGenVar.dir/all] Error 2
make: *** [all] Error 2
```
These functions `type_descriptor_is_int()` and `value_type_id_2_type_descriptor()` must be inline.