### PR TITLE
[feature] add genomic_region

### DIFF
--- a/include/bio/genomic_region.hpp
+++ b/include/bio/genomic_region.hpp
@@ -1,0 +1,124 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2022, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2022, Knut Reinert & MPI für molekulare Genetik
+// Copyright (c) 2020-2022, deCODE Genetics
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/b.i.o./blob/master/LICENSE
+// -----------------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cassert>
+#include <limits>
+
+#include <bio/misc.hpp>
+
+/*!\file
+ * \brief Provides bio::genomic_region.
+ * \author Hannes Hauswedell <hannes.hauswedell AT decode.is>
+ */
+
+namespace bio
+{
+
+/*!\brief Represents an interval on a chromosome or contig.
+ * \tparam own Ownership of the #chrom member. See \ref shallow_vs_deep for more details.
+ * \ingroup bio
+ * \details
+ *
+ * This structure can be used to describe regions on chromosomes, contigs or other sequences.
+ *
+ * All member functions assume half-open intervals, and all member functions assume that
+ * the invariant `end >= beg` holds. The results are unspecified if either is not true.
+ *
+ * ### Interval notations
+ *
+ * 0-based half-open (`[beg, end)`) intervals are the default in this library, but in some
+ * places 1-based, closed intervals (`[beg, end]`) may be represented in this data structure. They will be explicitly
+ * noted as such.
+ */
+template <ownership own = ownership::deep>
+struct genomic_region
+{
+    //!\brief Type of the #chrom member.
+    using string_t = std::conditional_t<own == ownership::deep, std::string, std::string_view>;
+
+    //!\brief The chromosome or contig identifier .
+    string_t chrom;
+    //!\brief Beginning of the interval.
+    int64_t  beg = 0;
+    //!\brief End of the interval; must be >= #beg.
+    int64_t  end = std::numeric_limits<int64_t>::max();
+
+    //!\brief Defaulted comparison operators.
+    friend bool operator==(genomic_region const &, genomic_region const &)  = default;
+    //!\brief Defaulted comparison operators.
+    friend auto operator<=>(genomic_region const &, genomic_region const &) = default;
+
+    /*!\brief Checks whether this region lies before, over or beyond the given point.
+     * \param chrom The contig/chromosome string for the query position.
+     * \param pos   The query position.
+     * \returns std::weak_ordering denoting the relative position of the point.
+     * \details
+     *
+     * Returns:
+     *
+     *   * std::weak_ordering::less if this region ends before the point.
+     *   * std::weak_ordering::equivalent if the point is inside the region.
+     *   * std::weak_ordering::greater if this region begins beyond the point.
+     *
+     * The strings are compared lexicographically. The interval is assumed to be half-open, i.e. \p pos == #end will
+     * result in std::weak_ordering::greater.
+     */
+    std::weak_ordering relative_to(std::string_view const chrom, int64_t const pos) const
+    {
+        assert(beg <= end);
+        return std::tuple{std::string_view{this->chrom}, (pos < end)} <=> std::tuple{chrom, (pos >= beg)};
+    }
+
+    /*!\brief Checks whether this region lies before or beyond the given region or whether they overlap.
+     * \param rhs The region to compare.
+     * \returns std::weak_ordering denoting the relative position of the this region compared to rhs.
+     * \details
+     *
+     * Returns:
+     *
+     *   * std::weak_ordering::less if this region ends before \p rhs begins.
+     *   * std::weak_ordering::equivalent if they overlap.
+     *   * std::weak_ordering::greater if this region begins before after \p rhs ends.
+     *
+     * The strings are compared lexicographically. The interval is assumed to be half-open.
+     */
+    template <ownership own_ = ownership::deep>
+    std::weak_ordering relative_to(genomic_region<own_> const & rhs) const
+    {
+        assert(beg <= end);
+        assert(rhs.beg <= rhs.end);
+        return std::tuple{std::string_view{chrom}, (end > rhs.beg)} <=>
+               std::tuple{std::string_view{rhs.chrom}, (beg < rhs.end)};
+    }
+
+    /*!\brief Computes the distance/overlap of two regions.
+     * \param rhs The region to compare with.
+     * \returns See below.
+     * \details
+     *
+     * Returns:
+     *
+     *  * A negative value (the overlap) if the regions overlap.
+     *  * A positive value (the distance) if the regions do not overlap but are on the same chromosome.
+     *  * std::numeric_limits<int64_t>::max() if the regions have different #chrom values.
+     *
+     * The strings are compared lexicographically for identity. The interval is assumed to be half-open.
+     */
+    template <ownership own_ = ownership::deep>
+    int64_t distance(genomic_region<own_> const & rhs) const
+    {
+        assert(beg <= end);
+        assert(rhs.beg <= rhs.end);
+        return chrom == rhs.chrom ? std::max(beg, rhs.beg) - std::min(end, rhs.end)
+                                  : std::numeric_limits<int64_t>::max();
+    }
+};
+
+} // namespace bio

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -54,3 +54,4 @@ list_missing_unit_tests()
 # Top-level tests
 
 bio_test(record_test.cpp)
+bio_test(genomic_region_test.cpp)

--- a/test/unit/genomic_region_test.cpp
+++ b/test/unit/genomic_region_test.cpp
@@ -1,0 +1,97 @@
+// -----------------------------------------------------------------------------------------------------
+// Copyright (c) 2006-2020, Knut Reinert & Freie Universität Berlin
+// Copyright (c) 2016-2020, Knut Reinert & MPI für molekulare Genetik
+// This file may be used, modified and/or redistributed under the terms of the 3-clause BSD-License
+// shipped with this file and also available at: https://github.com/seqan/seqan3/blob/master/LICENSE.md
+// -----------------------------------------------------------------------------------------------------
+
+#include <seqan3/std/algorithm>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include <bio/genomic_region.hpp>
+
+struct genomic_region : public ::testing::Test
+{
+    bio::genomic_region<> reg0{"chr20", 100, 200};
+    bio::genomic_region<> reg1{"chr20", 100, 200};
+    bio::genomic_region<> reg2{"chr20", 100, 150};
+    bio::genomic_region<> reg3{"chr20", 150, 200};
+    bio::genomic_region<> reg4{"chr20", 50, 100};
+    bio::genomic_region<> reg5{"chr20", 200, 250};
+    bio::genomic_region<> reg6{"chr21", 100, 200};
+};
+
+TEST_F(genomic_region, construction_deduction)
+{
+    bio::genomic_region reg0{"chr20", 100, 200};
+    EXPECT_TRUE((std::same_as<decltype(reg0), bio::genomic_region<>>));
+
+    bio::genomic_region<bio::ownership::deep> reg1{"chr20", 100, 200};
+    EXPECT_TRUE((std::same_as<decltype(reg1), bio::genomic_region<>>));
+    EXPECT_TRUE((std::same_as<decltype(reg1)::string_t, std::string>));
+
+    bio::genomic_region<bio::ownership::shallow> reg2{"chr20", 100, 200};
+    EXPECT_TRUE((std::same_as<decltype(reg2)::string_t, std::string_view>));
+}
+
+// just test some basics
+TEST_F(genomic_region, default_compare)
+{
+    EXPECT_EQ(reg0, reg1);
+
+    EXPECT_LT(reg0, reg3);
+    EXPECT_LT(reg0, reg5);
+    EXPECT_LT(reg0, reg6);
+    EXPECT_LT(reg1, reg3);
+
+    EXPECT_GT(reg0, reg4);
+    EXPECT_GT(reg0, reg4);
+    EXPECT_GT(reg6, reg1);
+}
+
+TEST_F(genomic_region, relative_to_region)
+{
+    EXPECT_TRUE(reg0.relative_to(reg1) == std::weak_ordering::equivalent);
+    EXPECT_TRUE(reg0.relative_to(reg2) == std::weak_ordering::equivalent);
+    EXPECT_TRUE(reg0.relative_to(reg3) == std::weak_ordering::equivalent);
+
+    EXPECT_TRUE(reg0.relative_to(reg4) == std::weak_ordering::greater);
+    EXPECT_TRUE(reg3.relative_to(reg4) == std::weak_ordering::greater);
+    EXPECT_TRUE(reg5.relative_to(reg4) == std::weak_ordering::greater);
+
+    EXPECT_TRUE(reg0.relative_to(reg5) == std::weak_ordering::less);
+    EXPECT_TRUE(reg0.relative_to(reg6) == std::weak_ordering::less);
+    EXPECT_TRUE(reg4.relative_to(reg5) == std::weak_ordering::less);
+}
+
+TEST_F(genomic_region, relative_to_point)
+{
+    EXPECT_TRUE(reg0.relative_to("chr20", 100) == std::weak_ordering::equivalent);
+    EXPECT_TRUE(reg0.relative_to("chr20", 150) == std::weak_ordering::equivalent);
+    EXPECT_TRUE(reg0.relative_to("chr20", 200) != std::weak_ordering::equivalent);
+
+    EXPECT_TRUE(reg0.relative_to("chr20", 99) == std::weak_ordering::greater);
+    EXPECT_TRUE(reg3.relative_to("chr19", 666) == std::weak_ordering::greater);
+    EXPECT_TRUE(reg5.relative_to("", 200) == std::weak_ordering::greater);
+
+    EXPECT_TRUE(reg0.relative_to("chr20", 200) == std::weak_ordering::less);
+    EXPECT_TRUE(reg0.relative_to("chr20", 201) == std::weak_ordering::less);
+    EXPECT_TRUE(reg4.relative_to("chr21", 1) == std::weak_ordering::less);
+}
+
+TEST_F(genomic_region, distance)
+{
+    EXPECT_TRUE(reg0.distance(reg1) == -100);
+    EXPECT_TRUE(reg0.distance(reg2) == -50);
+    EXPECT_TRUE(reg0.distance(reg3) == -50);
+
+    EXPECT_TRUE(reg0.distance(reg4) == 0);
+    EXPECT_TRUE(reg3.distance(reg4) == 50);
+    EXPECT_TRUE(reg5.distance(reg4) == 100);
+
+    EXPECT_TRUE(reg0.distance(reg5) == 0);
+    EXPECT_TRUE(reg0.distance(reg6) == std::numeric_limits<int64_t>::max());
+    EXPECT_TRUE(reg4.distance(reg5) == 100);
+}


### PR DESCRIPTION
We might need to discuss the position notation again. I wanted to stay as close as possible to the format, but this becomes really messy when we have regions (added here) and want to compute an overlap and don't know which notation is being used.

It is also possible to add a template parameter to this struct to switch the behaviour of the overlap algorithms between half-open and closed intervals, but that also adds complexity that I would like to avoid.

My proposal right now:
* genomic_region is always half-open, 0-based.
* the indexed access on var_io knows this and internally subtracts 1 from the position
* we evaluate at a later point (when we also have map IO) whether to consistently use 0-based, half-open throughout the library

OK?