### PR TITLE
Clang format++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -64,6 +64,7 @@ Cpp11BracedListStyle: true
 DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
 EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -81,6 +82,7 @@ IncludeCategories:
     Priority:        1
 IncludeBlocks: Preserve
 IncludeIsMainRegex: '(Test)?$'
+IndentAccessModifiers: false
 IndentCaseBlocks: true
 IndentCaseLabels: true
 IndentExternBlock: false
@@ -97,6 +99,7 @@ MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
+PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
@@ -105,7 +108,11 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Middle
+QualifierAlignment: Custom
+QualifierOrder: ['static', 'inline', 'constexpr', 'type', 'const', 'volatile', 'restrict' ]
+ReferenceAlignment: Middle
 ReflowComments:  true
+SeparateDefinitionBlocks: Leave
 SortIncludes:    CaseInsensitive
 SortIncludes: true
 SortUsingDeclarations: true

--- a/include/bio/detail/charconv.hpp
+++ b/include/bio/detail/charconv.hpp
@@ -36,9 +36,9 @@ namespace bio::detail
 std::to_chars_result to_chars(char * first, char * last, auto in)
 {
 #if defined(__cpp_lib_to_chars) && (__cpp_lib_to_chars >= 201611)
-    constexpr static bool float_support = true;
+    static constexpr bool float_support = true;
 #else
-    constexpr static bool float_support = false;
+    static constexpr bool float_support = false;
 #endif
 
     if constexpr (std::integral<decltype(in)> || float_support)
@@ -66,9 +66,9 @@ std::to_chars_result to_chars(char * first, char * last, auto in)
 std::from_chars_result from_chars(char const * first, char const * last, auto & out)
 {
 #if defined(__cpp_lib_to_chars) && (__cpp_lib_to_chars >= 201611)
-    constexpr static bool float_support = true;
+    static constexpr bool float_support = true;
 #else
-    constexpr static bool float_support = false;
+    static constexpr bool float_support = false;
 #endif
 
     // TODO always use fast_float here.

--- a/include/bio/stream/detail/bgzf_stream_util.hpp
+++ b/include/bio/stream/detail/bgzf_stream_util.hpp
@@ -39,7 +39,7 @@ namespace bio::contrib
 /*!\brief A static variable indicating the number of threads to use for the bgzf-streams.
  *       Defaults to std::thread::hardware_concurrency.
  */
-inline static uint64_t bgzf_thread_count = std::thread::hardware_concurrency();
+static inline uint64_t bgzf_thread_count = std::thread::hardware_concurrency();
 
 // ============================================================================
 // Forwards
@@ -87,10 +87,10 @@ struct CompressionContext<compression_format::bgzf> : CompressionContext<compres
 template <>
 struct DefaultPageSize<compression_format::bgzf>
 {
-    static const unsigned MAX_BLOCK_SIZE      = 64 * 1024;
-    static const unsigned BLOCK_FOOTER_LENGTH = 8;
+    static unsigned const MAX_BLOCK_SIZE      = 64 * 1024;
+    static unsigned const BLOCK_FOOTER_LENGTH = 8;
     // 5 bytes block overhead (see 3.2.4. at https://tools.ietf.org/html/rfc1951)
-    static const unsigned ZLIB_BLOCK_OVERHEAD = 5;
+    static unsigned const ZLIB_BLOCK_OVERHEAD = 5;
 
     // Reduce the maximal input size, such that the compressed data
     // always fits in one block even for level Z_NO_COMPRESSION.
@@ -98,7 +98,7 @@ struct DefaultPageSize<compression_format::bgzf>
     {
         BLOCK_HEADER_LENGTH = CompressionContext<compression_format::bgzf>::BLOCK_HEADER_LENGTH
     };
-    static const unsigned VALUE = MAX_BLOCK_SIZE - BLOCK_HEADER_LENGTH - BLOCK_FOOTER_LENGTH - ZLIB_BLOCK_OVERHEAD;
+    static unsigned const VALUE = MAX_BLOCK_SIZE - BLOCK_HEADER_LENGTH - BLOCK_FOOTER_LENGTH - ZLIB_BLOCK_OVERHEAD;
 };
 
 // ============================================================================
@@ -111,8 +111,8 @@ struct DefaultPageSize<compression_format::bgzf>
 
 inline void compressInit(CompressionContext<compression_format::gz> & ctx)
 {
-    const int GZIP_WINDOW_BITS    = -15; // no zlib header
-    const int Z_DEFAULT_MEM_LEVEL = 8;
+    int const GZIP_WINDOW_BITS    = -15; // no zlib header
+    int const Z_DEFAULT_MEM_LEVEL = 8;
 
     ctx.strm.zalloc = NULL;
     ctx.strm.zfree  = NULL;
@@ -238,7 +238,7 @@ inline TDestCapacity _compressBlock(TDestValue *                                
 
 inline void decompressInit(CompressionContext<compression_format::gz> & ctx)
 {
-    const int GZIP_WINDOW_BITS = -15; // no zlib header
+    int const GZIP_WINDOW_BITS = -15; // no zlib header
 
     ctx.strm.zalloc = NULL;
     ctx.strm.zfree  = NULL;

--- a/include/bio/stream/detail/bz2_ostream.hpp
+++ b/include/bio/stream/detail/bz2_ostream.hpp
@@ -198,7 +198,7 @@ bool basic_bz2_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::bzip2_to_stream(
             written_byte_size = static_cast<std::streamsize>(m_output_buffer.size()) - m_bzip2_stream.avail_out;
             total_written_byte_size += written_byte_size;
             // output buffer is full, dumping to ostream
-            m_ostream.write((const char_type *)&(m_output_buffer[0]),
+            m_ostream.write((char_type const *)&(m_output_buffer[0]),
                             static_cast<std::streamsize>(written_byte_size / sizeof(char_type)));
 
             // checking if some bytes were not written.
@@ -238,7 +238,7 @@ std::streamsize basic_bz2_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::flush(int 
             written_byte_size = static_cast<std::streamsize>(m_output_buffer.size()) - m_bzip2_stream.avail_out;
             total_written_byte_size += written_byte_size;
             // output buffer is full, dumping to ostream
-            m_ostream.write((const char_type *)&(m_output_buffer[0]),
+            m_ostream.write((char_type const *)&(m_output_buffer[0]),
                             static_cast<std::streamsize>(written_byte_size / sizeof(char_type) * sizeof(char)));
 
             // checking if some bytes were not written.

--- a/include/bio/stream/detail/gz_ostream.hpp
+++ b/include/bio/stream/detail/gz_ostream.hpp
@@ -218,7 +218,7 @@ bool basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::zip_to_stream(
             total_written_byte_size += written_byte_size;
 
             // output buffer is full, dumping to ostream
-            m_ostream.write((const char_type *)&(m_output_buffer[0]),
+            m_ostream.write((char_type const *)&(m_output_buffer[0]),
                             static_cast<std::streamsize>(written_byte_size / sizeof(char_type)));
 
             // checking if some bytes were not written.
@@ -259,7 +259,7 @@ std::streamsize basic_gz_ostreambuf<Elem, Tr, ElemA, ByteT, ByteAT>::flush(int f
             total_written_byte_size += written_byte_size;
 
             // output buffer is full, dumping to ostream
-            m_ostream.write((const char_type *)&(m_output_buffer[0]),
+            m_ostream.write((char_type const *)&(m_output_buffer[0]),
                             static_cast<std::streamsize>(written_byte_size / sizeof(char_type) * sizeof(byte_type)));
 
             // checking if some bytes were not written.


### PR DESCRIPTION
Clang-format can now enforce more of style-guide, including east-const and qualifier order. Most of this has been done before, so the diff is very small.