### PR TITLE
Region filtering

### DIFF
--- a/include/bio/format/format_input_handler.hpp
+++ b/include/bio/format/format_input_handler.hpp
@@ -206,24 +206,34 @@ private:
     //!\}
 
 public:
+    /*!\name Read and parse record
+     * \brief Most users should not use these interfaces; use bio::*::reader instead.
+     * \{
+     */
+    //!\brief Advance to the next record and update the "raw record".
+    void read_next_raw_record() { to_derived()->read_raw_record(); }
+
+    /*!\brief Convert the currently held "raw record" into the record given as argument. This does not perform I/O.
+     * \param[out] parsed_record The out-parameter.
+     */
+    void parse_current_record_into(auto & parsed_record)
+    {
+        parsed_record.clear(); // TODO it might be beneficial to not clear and better reuse better memory
+        to_derived()->parse_record(typename derived_t::format_fields{}, parsed_record);
+    }
+
     /*!\brief Parse input into the record argument.
      * \param[out] parsed_record The out-parameter.
      * \details
      *
-     * ### Attention
-     *
-     * Most users should not use this interface and should instead use formatted readers, e.g.
-     * bio::map_io::reader, bio::seq_io::reader or bio::var_io::reader.
+     * Convenience function that reads the next raw record and then parses it.
      */
     void parse_next_record_into(auto & parsed_record)
     {
-        // create new raw record
-        to_derived()->read_raw_record();
-
-        // create new parsed record
-        parsed_record.clear();
-        to_derived()->parse_record(typename derived_t::format_fields{}, parsed_record);
+        read_next_raw_record();
+        parse_current_record_into(parsed_record);
     }
+    //!\}
 };
 
 } // namespace bio

--- a/include/bio/seq_io/reader.hpp
+++ b/include/bio/seq_io/reader.hpp
@@ -100,11 +100,24 @@ namespace bio::seq_io
  * For more advanced options, see bio::seq_io::reader_options.
  */
 template <typename... option_args_t>
-class reader : public reader_base<reader_options<option_args_t...>>
+class reader : public reader_base<reader<option_args_t...>, reader_options<option_args_t...>>
 {
 private:
+    /*!\name CRTP related entities
+     * \{
+     */
     //!\brief The base class.
-    using base_t = reader_base<reader_options<option_args_t...>>;
+    using base_t = reader_base<reader<option_args_t...>, reader_options<option_args_t...>>;
+    //!\brief Befriend CRTP-base.
+    friend base_t;
+    //!\cond
+    // Doxygen is confused by this for some reason
+    friend detail::in_file_iterator<reader>;
+    //!\endcond
+
+    //!\brief Expose the options type to the base-class.
+    using options_t = reader_options<option_args_t...>;
+    //!\}
 
 public:
     //!\brief Inherit the format_type definition.

--- a/include/bio/var_io/reader.hpp
+++ b/include/bio/var_io/reader.hpp
@@ -92,11 +92,16 @@ namespace bio::var_io
  * For more advanced options, see bio::var_io::reader_options.
  */
 template <typename... option_args_t>
-class reader : public reader_base<reader_options<option_args_t...>>
+class reader : public reader_base<reader<option_args_t...>, reader_options<option_args_t...>>
 {
 private:
     //!\brief The base class.
-    using base_t      = reader_base<reader_options<option_args_t...>>;
+    using base_t      = reader_base<reader<option_args_t...>, reader_options<option_args_t...>>;
+
+    //!\brief Expose the options type to the base-class.
+    using options_t   = reader_options<option_args_t...>;
+
+
     //!\brief Inherit the format_type definition.
     using format_type = typename base_t::format_type;
     /* Implementation note

--- a/include/bio/var_io/reader.hpp
+++ b/include/bio/var_io/reader.hpp
@@ -95,26 +95,103 @@ template <typename... option_args_t>
 class reader : public reader_base<reader<option_args_t...>, reader_options<option_args_t...>>
 {
 private:
+    /*!\name CRTP related entities
+     * \{
+     */
     //!\brief The base class.
-    using base_t      = reader_base<reader<option_args_t...>, reader_options<option_args_t...>>;
+    using base_t = reader_base<reader<option_args_t...>, reader_options<option_args_t...>>;
+    //!\brief Befriend CRTP-base.
+    friend base_t;
+    //!\cond
+    // Doxygen is confused by this for some reason
+    friend detail::in_file_iterator<reader>;
+    //!\endcond
 
     //!\brief Expose the options type to the base-class.
-    using options_t   = reader_options<option_args_t...>;
+    using options_t = reader_options<option_args_t...>;
+    //!\}
 
-
-    //!\brief Inherit the format_type definition.
-    using format_type = typename base_t::format_type;
-    /* Implementation note
-     * format_type is "inherited" as private here to avoid appearing twice in the documentation.
-     * Its actual visibility is public because it is public in the base class.
+    /*!\name Member data
+     * \{
      */
-    //!\brief Make the format handler visible.
+    //!\cond
+    using base_t::at_end;
     using base_t::format_handler;
+    using base_t::options;
+    using base_t::record_buffer;
+    using base_t::stream;
+    //!\endcond
 
     //!\brief A pointer to the header inside the format.
-    bio::var_io::header const * header_ptr = nullptr;
+    var_io::header const * header_ptr = nullptr;
+    //!\}
+
+    //!\brief Tell the format to move to the next record and update the buffer.
+    void read_next_record()
+    {
+        if (at_end)
+            return;
+
+        // at end if we could not read further
+        if (std::istreambuf_iterator<char>{stream} == std::istreambuf_iterator<char>{})
+        {
+            at_end = true;
+            return;
+        }
+
+        assert(!format_handler.valueless_by_exception());
+
+        if (options.region.chrom.empty()) // regular, unrestricted reading
+        {
+            std::visit([&](auto & f) { f.parse_next_record_into(record_buffer); }, format_handler);
+        }
+        else // only read on sub-region
+        {
+            // this record holds the bare minimum to check if regions overlap; always shallow
+            using record_t = record<vtag_t<field::chrom, field::pos, field::ref>,
+                                    seqan3::type_list<std::string_view, int64_t, std::string_view>>;
+            record_t temp_record;
+
+            while (true)
+            {
+                // at end if we could not read further
+                if (std::istreambuf_iterator<char>{stream} == std::istreambuf_iterator<char>{})
+                {
+                    at_end = true;
+                    break;
+                }
+
+                std::visit([&](auto & f) { f.parse_next_record_into(temp_record); }, format_handler);
+
+                // TODO undo "- 1" if interval notation gets decided on
+                genomic_region<ownership::shallow> rec_reg{.chrom = temp_record.chrom(),
+                                                           .beg   = temp_record.pos() - 1,
+                                                           .end   = rec_reg.beg + (int64_t)temp_record.ref().size()};
+
+                std::weak_ordering ordering = rec_reg.relative_to(options.region);
+                if (ordering == std::weak_ordering::less) // records lies before the target region → skip
+                {
+                    continue;
+                }
+                else if (ordering == std::weak_ordering::equivalent) // records overlaps target region → take it
+                {
+                    // full parsing of the same record
+                    std::visit([&](auto & f) { f.parse_current_record_into(record_buffer); }, format_handler);
+                    break;
+                }
+                else if (ordering == std::weak_ordering::greater) // record begins after target region start → at end
+                {
+                    at_end = true;
+                    break;
+                }
+            }
+        }
+    }
 
 public:
+    //!\brief Inherit the format_type definition.
+    using format_type = typename base_t::format_type;
+
     // clang-format off
     //!\copydoc bio::reader_base::reader_base(std::filesystem::path const & filename, format_type const & fmt, options_t const & opt = options_t{})
     // clang-format on

--- a/test/unit/var_io/var_io_reader_test.cpp
+++ b/test/unit/var_io/var_io_reader_test.cpp
@@ -280,3 +280,31 @@ TEST(var_io_reader, decompression_stream)
     }
     EXPECT_EQ(count, 5);
 }
+
+TEST(var_io_reader, region_filter)
+{
+    bio::genomic_region<>       region{.chrom = "20", .beg = 17000, .end = 1230300};
+    bio::var_io::reader_options options{.region = region};
+
+    {
+        std::istringstream  str{static_cast<std::string>(example_from_spec)};
+        bio::var_io::reader reader{str, bio::vcf{}, options};
+
+        EXPECT_EQ(std::ranges::distance(reader), 3);
+    }
+
+    {
+        std::istringstream  str{static_cast<std::string>(example_from_spec)};
+        bio::var_io::reader reader{str, bio::vcf{}, options};
+
+        size_t count = 0;
+        for (auto & rec : reader)
+        {
+            ++count;
+            EXPECT_EQ(rec.chrom(), "20");
+            EXPECT_GE(rec.pos(), region.beg);
+            EXPECT_LT(rec.pos(), region.end);
+        }
+        EXPECT_EQ(count, 3);
+    }
+}


### PR DESCRIPTION
This contains non-index-based filtering for var_io. It also contains most of the interfaces for index-based filtering, but I will add that in a later PR.

I thought a lot about this and I think it works quite nicely with the current abstractions, so that all of this happens in the reader and none of it in the format. I had to make the reader-inheritance CRTP though.